### PR TITLE
fix #37

### DIFF
--- a/algorithmic/sky-judge.yaml
+++ b/algorithmic/sky-judge.yaml
@@ -40,7 +40,7 @@ setup: |
 
 run: |
   set -euo pipefail
-  cd ~/algorithmic
+  cd ~/algorithmic/algorithmic
 
   # Build and start go-judge service
   echo "Building and starting go-judge..."
@@ -62,12 +62,5 @@ run: |
   echo "Go-Judge service is running on port 8081"
   echo "=========================================="
   echo ""
-  echo "To get the IP address:"
-  echo "  sky status --ip algo-judge"
+  echo "Service logs: sudo docker-compose -f ~/algorithmic/algorithmic/docker-compose.yml logs -f"
   echo ""
-  echo "To evaluate:"
-  echo "  frontier-eval --algorithmic --judge-url http://<ip>:8081 1 solution.cpp"
-  echo ""
-
-  # Keep running (tail logs)
-  sudo docker-compose logs -f

--- a/src/frontier_cs/runner/algorithmic_skypilot.py
+++ b/src/frontier_cs/runner/algorithmic_skypilot.py
@@ -44,6 +44,9 @@ class AlgorithmicSkyPilotRunner(AlgorithmicRunner):
             keep_cluster: Keep cluster running after evaluation (disables autostop)
             idle_timeout: Minutes of idleness before autostop (default: 10, None to disable)
         """
+        # Initialize parent class
+        super().__init__(judge_url="http://localhost:8081")  # Placeholder, will be updated
+        
         self.base_dir = base_dir or self._find_base_dir()
         self.cloud = cloud
         self.region = region
@@ -110,15 +113,17 @@ class AlgorithmicSkyPilotRunner(AlgorithmicRunner):
             cmd.extend(["--idle-minutes-to-autostop", str(self.idle_timeout)])
 
         try:
-            # Launch in background-ish mode (don't wait for logs to finish)
+            # Run synchronously - sky launch waits for cluster to be ready
+            print(f"Launching cluster {self.CLUSTER_NAME}... (this may take a few minutes)")
             result = subprocess.run(
                 cmd,
-                capture_output=True,
                 text=True,
-                timeout=600,  # 10 minutes max for launch
+                timeout=1800,  # 30 minutes max for launch
             )
+            print(f"Launch command completed with return code {result.returncode}")
             return result.returncode == 0
         except subprocess.TimeoutExpired:
+            print("Launch timed out after 30 minutes")
             return False
 
     def _wait_for_service(self, ip: str, timeout: int = 120) -> bool:
@@ -153,16 +158,17 @@ class AlgorithmicSkyPilotRunner(AlgorithmicRunner):
 
         if ip:
             # Cluster exists, check if service is ready
-            if self._wait_for_service(ip, timeout=10):
+            print(f"Found existing cluster at {ip}")
+            if self._wait_for_service(ip, timeout=30):
                 self._judge_url = f"http://{ip}:8081"
                 self._initialized = True
                 return self._judge_url
 
         # Need to launch cluster
-        print(f"Launching {self.CLUSTER_NAME} cluster on {self.cloud}...")
         if not self._launch_cluster():
             raise RuntimeError("Failed to launch algo-judge cluster")
 
+        # sky launch is synchronous, so cluster should be ready
         # Get IP and wait for service
         ip = self._get_cluster_ip()
         if not ip:


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This PR fixes #37 by addressing two issues that affect the current Python API when used with SkyPilot:

1. Incorrect Docker working directory in `sky-judge.yaml`
   The correct Docker path should be `./algorithmic/algorithmic` instead of `./algorithmic`:
   https://github.com/FrontierCS/Frontier-CS/blob/14447b989fba52c15593b5ecba495c4adcf82821/algorithmic/sky-judge.yaml#L43
   In addition, the judge logs should be detached to avoid blocking:
   https://github.com/FrontierCS/Frontier-CS/blob/14447b989fba52c15593b5ecba495c4adcf82821/algorithmic/sky-judge.yaml#L73

2. Insufficient timeout during initial judge server startup
   The original timeout is too short for the first launch of the judge server, which can easily cause the Python API to fail on first use. Increasing the timeout resolves this issue.
   Subsequent runs via the CLI typically succeed because the server has already been launched.




## Type of Change
- [ ] New research problem
- [ ] New algorithmic problem
- [x] Bug fix
- [ ] Documentation update
- [ ] Other:

## Testing
I test the following code with SkyPilot on GCP
```python
from pathlib import Path
from frontier_cs import FrontierCSEvaluator

evaluator = FrontierCSEvaluator()
my_code = Path("./algorithmic/problems/0/examples/gpt5.cpp").read_text(
    encoding="utf-8"
)
# Single problem
result = evaluator.evaluate("algorithmic", problem_id="0", code=my_code, backend="skypilot")
print(f"Score: {result.score}")
print(f"message: {result.message}")
```
It now works correctly with
```
...
Launch command completed with return code 0
Waiting for judge service at 35.193.98.57:8081...
Judge service ready at http://35.193.98.57:8081
Score: 44.332868064285705
message: None
```

## Checklist
- [x] Code follows the project structure and conventions
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
