### PR TITLE
add --timeout for cli eval

### DIFF
--- a/src/frontier_cs/batch/evaluator.py
+++ b/src/frontier_cs/batch/evaluator.py
@@ -71,7 +71,7 @@ class BatchEvaluator:
         track: str = "research",
         workers: int = 1,
         clusters: Optional[int] = None,
-        timeout: Optional[int] = 300,  # Default 5 min timeout per evaluation
+        timeout: Optional[int] = 1000,  # Default 1000s timeout per evaluation
         bucket_url: Optional[str] = None,
         keep_cluster: bool = False,
         idle_timeout: Optional[int] = 10,
@@ -162,6 +162,7 @@ class BatchEvaluator:
                 return DockerRunner(
                     base_dir=self.base_dir,
                     problems_dir=self.problems_dir,
+                    timeout=self.timeout,
                 )
             else:
                 from ..runner.skypilot import SkyPilotRunner

--- a/src/frontier_cs/evaluator.py
+++ b/src/frontier_cs/evaluator.py
@@ -43,6 +43,7 @@ class FrontierCSEvaluator:
         region: Optional[str] = None,
         keep_cluster: bool = False,
         idle_timeout: Optional[int] = 10,
+        timeout: Optional[int] = None,
     ):
         """
         Initialize FrontierCSEvaluator.
@@ -55,6 +56,7 @@ class FrontierCSEvaluator:
             region: Cloud region for SkyPilot
             keep_cluster: Keep SkyPilot cluster running after evaluation (disables autostop)
             idle_timeout: Minutes of idleness before autostop (default: 10, None to disable)
+            timeout: Timeout per evaluation in seconds (default: None, uses runner default)
         """
         self.default_backend = backend
         self.base_dir = base_dir
@@ -63,6 +65,7 @@ class FrontierCSEvaluator:
         self.region = region
         self.keep_cluster = keep_cluster
         self.idle_timeout = idle_timeout
+        self.timeout = timeout
 
         # Lazy-initialized runners
         self._algorithmic_runner: Optional[AlgorithmicRunner] = None
@@ -95,7 +98,7 @@ class FrontierCSEvaluator:
     def docker_runner(self) -> DockerRunner:
         """Get or create the Docker runner."""
         if self._docker_runner is None:
-            self._docker_runner = DockerRunner(base_dir=self.base_dir)
+            self._docker_runner = DockerRunner(base_dir=self.base_dir, timeout=self.timeout)
         return self._docker_runner
 
     @property

--- a/src/frontier_cs/runner/base.py
+++ b/src/frontier_cs/runner/base.py
@@ -44,7 +44,7 @@ class Runner(ABC):
     """Abstract base class for evaluation runners."""
 
     # Default timeout in seconds. Subclasses can override.
-    DEFAULT_TIMEOUT: int = 300  # 5 minutes
+    DEFAULT_TIMEOUT: int = 1000  # ~17 minutes
 
     @abstractmethod
     def evaluate(


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request increases the default evaluation timeout across the codebase from 300 seconds (5 minutes) to 1000 seconds (~17 minutes) and adds support for user-configurable timeouts via command-line arguments and API parameters. The changes ensure that the timeout setting is consistently propagated through the evaluator, runner, and CLI layers, and that user-specified values take precedence over defaults or problem-specific configurations.

**Timeout configuration improvements:**

* Increased the default timeout for evaluations from 300 seconds to 1000 seconds in `BatchEvaluator`, `Runner`, and CLI argument defaults. [[1]](diffhunk://#diff-67b7884385cfea754fead7c61923e5a0729e430df77da944da6fc4b80cdf7ee1L74-R74) [[2]](diffhunk://#diff-8e2a5a2e237289b8eaf126aa3b40bf007c4bdcfcdb25fea90f43c3bd75edee37L47-R47) [[3]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR196-R201) [[4]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR329-R334)
* Added `timeout` as a configurable parameter in the CLI for both evaluation and batch modes, allowing users to set the evaluation timeout via `--timeout`. [[1]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR196-R201) [[2]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR329-R334)
* Ensured that the `timeout` parameter is passed through from the CLI to the evaluator and from the evaluator to the runner, so user-specified values are respected throughout the stack. [[1]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR513) [[2]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR522) [[3]](diffhunk://#diff-d6c9e542d6f86f8fabbc1ef73be47500edf3bd9afde3f38c597effc19d28dccfR761-R769) [[4]](diffhunk://#diff-4dcd27d40feb2be14e5f1ff8ebfd4529dcfd4be01c8dd3e449600403048799e5R46) [[5]](diffhunk://#diff-4dcd27d40feb2be14e5f1ff8ebfd4529dcfd4be01c8dd3e449600403048799e5R59) [[6]](diffhunk://#diff-4dcd27d40feb2be14e5f1ff8ebfd4529dcfd4be01c8dd3e449600403048799e5R68) [[7]](diffhunk://#diff-67b7884385cfea754fead7c61923e5a0729e430df77da944da6fc4b80cdf7ee1R165) [[8]](diffhunk://#diff-4dcd27d40feb2be14e5f1ff8ebfd4529dcfd4be01c8dd3e449600403048799e5L98-R101)

**Runner and evaluator enhancements:**

* Updated the `DockerRunner` and `Runner` base classes to accept and store a `timeout` parameter, and clarified the precedence: user-specified timeout > problem config > default. [[1]](diffhunk://#diff-e8ecb16f4e57fdab5e182663e1b8bba031ab2e1af142e7d48386c8049e8ef713R38) [[2]](diffhunk://#diff-e8ecb16f4e57fdab5e182663e1b8bba031ab2e1af142e7d48386c8049e8ef713R47-R51) [[3]](diffhunk://#diff-e8ecb16f4e57fdab5e182663e1b8bba031ab2e1af142e7d48386c8049e8ef713L152-R158)
* Updated documentation strings and parameter lists to reflect the new timeout handling and defaults. [[1]](diffhunk://#diff-e8ecb16f4e57fdab5e182663e1b8bba031ab2e1af142e7d48386c8049e8ef713R47-R51) [[2]](diffhunk://#diff-4dcd27d40feb2be14e5f1ff8ebfd4529dcfd4be01c8dd3e449600403048799e5R59)

These changes make the evaluation timeout more flexible and user-friendly, while also increasing the default to accommodate longer-running evaluations.

## Type of Change
- [ ] New research problem
- [ ] New algorithmic problem
- [ ] Bug fix
- [ ] Documentation update
- [x] Other:

## Testing
<!-- How were these changes tested? -->


## Checklist
- [ ] Code follows the project structure and conventions
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
