### PR TITLE
[research] Add a new problem of nbody simulation

### DIFF
--- a/research/problems/nbody_simulation/common/baseline.cpp
+++ b/research/problems/nbody_simulation/common/baseline.cpp
@@ -1,0 +1,39 @@
+// Baseline for N-body simulation - simple OpenMP parallel brute-force
+// O(N²) approach with parallel outer loop
+// Solutions should aim to beat this baseline
+
+#include "world.h"
+#include <omp.h>
+
+class BaselineSimulator : public Simulator {
+private:
+    int numThreads = 16;
+    
+public:
+    void init(int numParticles, StepParameters params) override {
+        omp_set_num_threads(numThreads);
+    }
+    
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        #pragma omp parallel for schedule(dynamic, 16)
+        for (int i = 0; i < (int)particles.size(); i++) {
+            auto pi = particles[i];
+            Vec2 force = Vec2(0.0f, 0.0f);
+            
+            for (size_t j = 0; j < particles.size(); j++) {
+                if (j == (size_t)i) continue;
+                if ((pi.position - particles[j].position).length() < params.cullRadius) {
+                    force += computeForce(pi, particles[j], params.cullRadius);
+                }
+            }
+            
+            newParticles[i] = updateParticle(pi, force, params.deltaTime);
+        }
+    }
+};
+
+Simulator* createBaselineSimulator() {
+    return new BaselineSimulator();
+}

--- a/research/problems/nbody_simulation/common/benchmark.cpp
+++ b/research/problems/nbody_simulation/common/benchmark.cpp
@@ -1,0 +1,183 @@
+// Benchmark harness for N-body simulation
+// This file includes the submitted solution and baseline, then runs benchmarks
+
+#include "world.h"
+#include "timing.h"
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <omp.h>
+
+// Forward declaration for baseline factory
+Simulator* createBaselineSimulator();
+
+struct BenchmarkOptions {
+  int numParticles = 10000;
+  int numIterations = 5;
+  float spaceSize = 100.0f;
+  int numRuns = 1;  // Temporarily set to 1 for optimization testing
+  bool checkCorrectness = true;
+  std::string outputFile = "result.txt";
+};
+
+BenchmarkOptions parseOptions(int argc, char** argv) {
+  BenchmarkOptions opts;
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
+      opts.numParticles = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-i") == 0 && i + 1 < argc) {
+      opts.numIterations = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-s") == 0 && i + 1 < argc) {
+      opts.spaceSize = (float)atof(argv[++i]);
+    } else if (strcmp(argv[i], "-r") == 0 && i + 1 < argc) {
+      opts.numRuns = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) {
+      opts.outputFile = argv[++i];
+    } else if (strcmp(argv[i], "--no-check") == 0) {
+      opts.checkCorrectness = false;
+    }
+  }
+  return opts;
+}
+
+bool checkForCorrectness(const World& refW, const World& w, float tolerance = 1e-2f) {
+  if (w.particles.size() != refW.particles.size()) {
+    std::cerr << "Mismatch: number of particles " << w.particles.size()
+              << " does not match reference " << refW.particles.size() << std::endl;
+    return false;
+  }
+
+  for (size_t i = 0; i < w.particles.size(); i++) {
+    auto errorX = std::abs(w.particles[i].position.x - refW.particles[i].position.x);
+    auto errorY = std::abs(w.particles[i].position.y - refW.particles[i].position.y);
+    if (errorX > tolerance || errorY > tolerance) {
+      std::cerr << "Mismatch at index " << i
+                << ": result (" << w.particles[i].position.x << ", "
+                << w.particles[i].position.y << ")"
+                << " should be (" << refW.particles[i].position.x << ", "
+                << refW.particles[i].position.y << ")" << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+double runSimulation(World& world, Simulator* sim, 
+                     StepParameters params, int numIterations) {
+  Timer timer;
+  timer.reset();
+  
+  // Initialize simulator at the start of each run (clean state)
+  sim->init(world.particles.size(), params);
+  
+  for (int iter = 0; iter < numIterations; iter++) {
+    world.newParticles.resize(world.particles.size());
+    sim->simulateStep(world.particles, world.newParticles, params);
+    world.particles.swap(world.newParticles);
+  }
+  
+  return timer.elapsed();
+}
+
+int main(int argc, char** argv) {
+  BenchmarkOptions opts = parseOptions(argc, argv);
+  
+  // Note: Solutions can set their own thread count via omp_set_num_threads()
+  std::cout << "Max OpenMP threads available: " << omp_get_max_threads() << std::endl;
+  
+  StepParameters params;
+  params.cullRadius = opts.spaceSize / 4.0f;
+  params.deltaTime = 0.2f;
+  
+  std::cout << "N-Body Simulation Benchmark" << std::endl;
+  std::cout << "Particles: " << opts.numParticles << std::endl;
+  std::cout << "Iterations: " << opts.numIterations << std::endl;
+  std::cout << "Space size: " << opts.spaceSize << std::endl;
+  std::cout << "Cull radius: " << params.cullRadius << std::endl;
+  std::cout << std::endl;
+  
+  // Create simulators
+  Simulator* baselineSim = createBaselineSimulator();
+  Simulator* solutionSim = createSimulator();
+  
+  // Benchmark sequential baseline
+  std::vector<double> seqTimes;
+  for (int run = 0; run < opts.numRuns; run++) {
+    World seqWorld;
+    seqWorld.generateRandom(opts.numParticles, opts.spaceSize);
+    double elapsed = runSimulation(seqWorld, baselineSim, params, opts.numIterations);
+    seqTimes.push_back(elapsed);
+    std::cout << "Sequential run " << (run + 1) << ": " << std::fixed 
+              << std::setprecision(4) << elapsed << "s" << std::endl;
+  }
+  
+  // Sort and get median
+  std::sort(seqTimes.begin(), seqTimes.end());
+  double seqMedian = seqTimes[opts.numRuns / 2];
+  std::cout << "Sequential median: " << std::fixed << std::setprecision(4) 
+            << seqMedian << "s" << std::endl << std::endl;
+  
+  // Benchmark submitted solution
+  std::vector<double> parTimes;
+  World finalWorld;
+  for (int run = 0; run < opts.numRuns; run++) {
+    World parWorld;
+    parWorld.generateRandom(opts.numParticles, opts.spaceSize);
+    double elapsed = runSimulation(parWorld, solutionSim, params, opts.numIterations);
+    parTimes.push_back(elapsed);
+    std::cout << "Solution run " << (run + 1) << ": " << std::fixed 
+              << std::setprecision(4) << elapsed << "s" << std::endl;
+    if (run == opts.numRuns - 1) {
+      finalWorld = parWorld;
+    }
+  }
+  
+  std::sort(parTimes.begin(), parTimes.end());
+  double parMedian = parTimes[opts.numRuns / 2];
+  std::cout << "Solution median: " << std::fixed << std::setprecision(4) 
+            << parMedian << "s" << std::endl << std::endl;
+  
+  // Check correctness
+  bool correct = true;
+  if (opts.checkCorrectness) {
+    std::cout << "Checking correctness..." << std::endl;
+    World refWorld;
+    refWorld.generateRandom(opts.numParticles, opts.spaceSize);
+    runSimulation(refWorld, baselineSim, params, opts.numIterations);
+    
+    World testWorld;
+    testWorld.generateRandom(opts.numParticles, opts.spaceSize);
+    runSimulation(testWorld, solutionSim, params, opts.numIterations);
+    
+    correct = checkForCorrectness(refWorld, testWorld);
+    if (correct) {
+      std::cout << "Correctness check: PASSED" << std::endl;
+    } else {
+      std::cout << "Correctness check: FAILED" << std::endl;
+    }
+  }
+  
+  // Calculate speedup
+  double speedup = seqMedian / parMedian;
+  std::cout << std::endl;
+  std::cout << "Speedup: " << std::fixed << std::setprecision(3) << speedup << "x" << std::endl;
+  
+  // Write results
+  std::ofstream outFile(opts.outputFile);
+  if (outFile) {
+    outFile << "sequential_time=" << std::fixed << std::setprecision(6) << seqMedian << std::endl;
+    outFile << "parallel_time=" << std::fixed << std::setprecision(6) << parMedian << std::endl;
+    outFile << "speedup=" << std::fixed << std::setprecision(6) << speedup << std::endl;
+    outFile << "correct=" << (correct ? "true" : "false") << std::endl;
+    outFile.close();
+  }
+  
+  // Cleanup
+  delete baselineSim;
+  delete solutionSim;
+  
+  return correct ? 0 : 1;
+}

--- a/research/problems/nbody_simulation/common/evaluator_common.py
+++ b/research/problems/nbody_simulation/common/evaluator_common.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Common evaluator logic for N-body simulation problem.
+
+This module contains shared evaluation logic used by all variants.
+Variant-specific evaluators configure parameters and call these functions.
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class VariantConfig:
+    """Configuration for a specific problem variant."""
+    num_particles: int
+    num_iterations: int
+    space_size: float
+    num_runs: int
+    # Scoring: maps speedup range [min_speedup, max_speedup] to [0, 100]
+    min_speedup: float  # Speedup that gives 0 points
+    max_speedup: float  # Speedup that gives 100 points
+
+
+def compile_and_run(
+    solution_path: Path,
+    work_dir: Path,
+    common_dir: Path,
+    config: VariantConfig
+) -> Dict[str, Any]:
+    """Compile the submitted C++ code with benchmark harness and run it."""
+    
+    # Copy common files to work directory
+    shutil.copy(common_dir / "world.h", work_dir / "world.h")
+    shutil.copy(common_dir / "timing.h", work_dir / "timing.h")
+    shutil.copy(common_dir / "benchmark.cpp", work_dir / "benchmark.cpp")
+    shutil.copy(common_dir / "baseline.cpp", work_dir / "baseline.cpp")
+    
+    # Copy the submitted solution
+    shutil.copy(solution_path, work_dir / "solution.cpp")
+    
+    # Create combined source that includes solution, baseline, and benchmark
+    combined_source = '''
+#include "solution.cpp"
+#include "baseline.cpp"
+#include "benchmark.cpp"
+'''
+    combined_file = work_dir / "combined.cpp"
+    combined_file.write_text(combined_source)
+    
+    # Compile
+    output_binary = work_dir / "nbody_benchmark"
+    compile_cmd = [
+        "g++", "-O2", "-fopenmp", "-std=c++17",
+        "-I", str(work_dir),
+        "-o", str(output_binary),
+        str(combined_file)
+    ]
+    
+    compile_result = subprocess.run(
+        compile_cmd,
+        capture_output=True,
+        text=True,
+        cwd=work_dir
+    )
+    
+    if compile_result.returncode != 0:
+        return {
+            "status": "compile_error",
+            "error": compile_result.stderr,
+            "score": 0,
+        }
+    
+    # Run benchmark
+    result_file = work_dir / "result.txt"
+    run_cmd = [
+        str(output_binary),
+        "-n", str(config.num_particles),
+        "-i", str(config.num_iterations),
+        "-s", str(config.space_size),
+        "-r", str(config.num_runs),
+        "-o", str(result_file)
+    ]
+    
+    run_result = subprocess.run(
+        run_cmd,
+        capture_output=True,
+        text=True,
+        cwd=work_dir,
+        timeout=600  # 10 minute timeout
+    )
+    
+    # Parse results
+    if not result_file.exists():
+        return {
+            "status": "runtime_error",
+            "error": run_result.stderr or "No result file generated",
+            "stdout": run_result.stdout,
+            "score": 0,
+        }
+    
+    results = {}
+    with open(result_file) as f:
+        for line in f:
+            if "=" in line:
+                key, value = line.strip().split("=", 1)
+                results[key] = value
+    
+    return {
+        "status": "success",
+        "sequential_time": float(results.get("sequential_time", 0)),
+        "parallel_time": float(results.get("parallel_time", 0)),
+        "speedup": float(results.get("speedup", 1)),
+        "correct": results.get("correct", "false") == "true",
+        "stdout": run_result.stdout,
+        "stderr": run_result.stderr,
+    }
+
+
+def calculate_score(speedup: float, correct: bool, config: VariantConfig) -> tuple[float, float]:
+    """Calculate bounded and unbounded scores.
+    
+    Score mapping:
+    - min_speedup = 0 points
+    - max_speedup = 100 points
+    - Linear interpolation between
+    - Capped at 100 for bounded, unbounded can exceed
+    """
+    if not correct:
+        return 0.0, 0.0
+    
+    # Linear mapping from [min_speedup, max_speedup] to [0, 100]
+    speedup_range = config.max_speedup - config.min_speedup
+    raw_score = (speedup - config.min_speedup) / speedup_range * 100.0
+    
+    bounded_score = max(0.0, min(100.0, raw_score))
+    unbounded_score = max(0.0, raw_score)
+    
+    return bounded_score, unbounded_score
+
+
+def evaluate(
+    solution_path: Path,
+    common_dir: Path,
+    config: VariantConfig
+) -> Dict[str, Any]:
+    """Main evaluation function."""
+    
+    try:
+        if not solution_path.exists():
+            raise FileNotFoundError(f"Solution file not found: {solution_path}")
+        
+        # Check file extension
+        if solution_path.suffix != ".cpp":
+            raise ValueError(f"Solution must be a .cpp file, got: {solution_path.suffix}")
+        
+        # Create temp directory and run
+        with tempfile.TemporaryDirectory() as temp_dir:
+            work_dir = Path(temp_dir)
+            run_result = compile_and_run(solution_path, work_dir, common_dir, config)
+        
+        if run_result["status"] != "success":
+            return {
+                "status": run_result["status"],
+                "error": run_result.get("error", "Unknown error"),
+                "score": 0,
+                "score_unbounded": 0,
+            }
+        
+        # Calculate score
+        bounded, unbounded = calculate_score(
+            run_result["speedup"],
+            run_result["correct"],
+            config
+        )
+        
+        return {
+            "status": "success",
+            "sequential_time": run_result["sequential_time"],
+            "parallel_time": run_result["parallel_time"],
+            "speedup": run_result["speedup"],
+            "correct": run_result["correct"],
+            "score": bounded,
+            "score_unbounded": unbounded,
+            "stdout": run_result.get("stdout", ""),
+            "stderr": run_result.get("stderr", ""),
+        }
+        
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "timeout",
+            "error": "Execution timed out",
+            "score": 0,
+            "score_unbounded": 0,
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": str(e),
+            "score": 0,
+            "score_unbounded": 0,
+        }
+
+
+def run_evaluator(config: VariantConfig, default_spec: Path):
+    """Main entry point for variant evaluators."""
+    parser = argparse.ArgumentParser(description="Evaluate N-body simulation solutions")
+    parser.add_argument(
+        "--solution-path",
+        type=Path,
+        default=Path("./solution.cpp"),
+        help="Path to solution.cpp file",
+    )
+    parser.add_argument(
+        "--spec-path",
+        type=Path,
+        default=default_spec,
+        help="Path to specification file",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("./result.json"),
+        help="Path to output result file",
+    )
+    
+    args = parser.parse_args()
+    
+    # Determine common directory (parent of the variant directory)
+    here = Path(__file__).resolve().parent
+    common_dir = here  # evaluator_common.py is already in common/
+    
+    # Run evaluation
+    result = evaluate(args.solution_path, common_dir, config)
+    
+    # Write result
+    with args.output_path.open("w", encoding="utf-8") as fout:
+        json.dump(result, fout, indent=2)
+    
+    # Print benchmark output
+    if result.get("stdout"):
+        print(result["stdout"])
+    
+    # Print summary
+    if result["status"] == "success":
+        print(f"Evaluation completed successfully!")
+        print(f"Speedup: {result.get('speedup', 0):.3f}x")
+        print(f"Correct: {result.get('correct', False)}")
+        print(f"Score: {result.get('score', 0):.2f}/100")
+        # Print stderr if correctness failed (contains mismatch details)
+        if not result.get('correct', False) and result.get('stderr'):
+            print(f"Correctness error details:\n{result.get('stderr')}")
+        # Print score as last line for framework to extract
+        score = result.get("score", 0)
+        score_unbounded = result.get("score_unbounded", score)
+        print(f"{score} {score_unbounded}")
+    else:
+        print(f"Evaluation failed: {result.get('error', 'Unknown error')}")
+        print("0")
+        sys.exit(1)
+

--- a/research/problems/nbody_simulation/common/timing.h
+++ b/research/problems/nbody_simulation/common/timing.h
@@ -1,0 +1,20 @@
+#ifndef TIMING_H
+#define TIMING_H
+
+#include <chrono>
+
+class Timer {
+public:
+  Timer() : beg_(clock_::now()) {}
+  void reset() { beg_ = clock_::now(); }
+  double elapsed() const {
+    return std::chrono::duration_cast<second_>(clock_::now() - beg_).count();
+  }
+
+private:
+  typedef std::chrono::high_resolution_clock clock_;
+  typedef std::chrono::duration<double, std::ratio<1>> second_;
+  std::chrono::time_point<clock_> beg_;
+};
+
+#endif

--- a/research/problems/nbody_simulation/common/world.h
+++ b/research/problems/nbody_simulation/common/world.h
@@ -1,0 +1,159 @@
+#ifndef NBODY_WORLD_H
+#define NBODY_WORLD_H
+
+#include <cmath>
+#include <memory>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+#include <cstdlib>
+
+struct Vec2 {
+  float x, y;
+  Vec2(float vx = 0.0f, float vy = 0.0f) : x(vx), y(vy) {}
+  static float dot(Vec2 v0, Vec2 v1) { return v0.x * v1.x + v0.y * v1.y; }
+  float &operator[](int i) { return ((float *)this)[i]; }
+  Vec2 operator*(float s) const { return Vec2(*this) *= s; }
+  Vec2 operator*(Vec2 vin) const { return Vec2(*this) *= vin; }
+  Vec2 operator+(Vec2 vin) const { return Vec2(*this) += vin; }
+  Vec2 operator-(Vec2 vin) const { return Vec2(*this) -= vin; }
+  Vec2 operator-() const { return Vec2(-x, -y); }
+  Vec2 &operator+=(Vec2 vin) {
+    x += vin.x;
+    y += vin.y;
+    return *this;
+  }
+  Vec2 &operator-=(Vec2 vin) {
+    x -= vin.x;
+    y -= vin.y;
+    return *this;
+  }
+  Vec2 &operator=(float v) {
+    x = y = v;
+    return *this;
+  }
+  Vec2 &operator*=(float s) {
+    x *= s;
+    y *= s;
+    return *this;
+  }
+  Vec2 &operator*=(Vec2 vin) {
+    x *= vin.x;
+    y *= vin.y;
+    return *this;
+  }
+  float length2() const { return x * x + y * y; }
+  float length() const { return std::sqrt(length2()); }
+};
+
+struct Particle {
+  int id;
+  float mass;
+  Vec2 position;
+  Vec2 velocity;
+};
+
+// Do not modify this function.
+inline Vec2 computeForce(const Particle &target, const Particle &attractor,
+                         float cullRadius) {
+  auto dir = (attractor.position - target.position);
+  auto dist = dir.length();
+  if (dist < 1e-3f)
+    return Vec2(0.0f, 0.0f);
+  dir *= (1.0f / dist);
+  if (dist > cullRadius)
+    return Vec2(0.0f, 0.0f);
+  if (dist < 1e-1f)
+    dist = 1e-1f;
+  const float G = 0.01f;
+  Vec2 force = dir * target.mass * attractor.mass * (G / (dist * dist));
+  if (dist > cullRadius * 0.75f) {
+    float decay = 1.0f - (dist - cullRadius * 0.75f) / (cullRadius * 0.25f);
+    force *= decay;
+  }
+  return force;
+}
+
+inline Particle updateParticle(const Particle &pi, Vec2 force,
+                               float deltaTime) {
+  Particle result = pi;
+  result.velocity += force * (deltaTime / pi.mass);
+  result.position += result.velocity * deltaTime;
+  return result;
+}
+
+struct StepParameters {
+  float deltaTime = 0.2f;
+  float cullRadius = 1.0f;
+};
+
+// Random number generator for reproducible particle generation
+class Random {
+private:
+  unsigned int seed;
+
+public:
+  Random(int seed) : seed(seed) {}
+  int Next() {
+    return (((seed = seed * 214013L + 2531011L) >> 16) & 0x7fff);
+  }
+  int Next(int min, int max) {
+    unsigned int a = ((seed = seed * 214013L + 2531011L) & 0xFFFF0000);
+    unsigned int b = ((seed = seed * 214013L + 2531011L) >> 16);
+    unsigned int r = a + b;
+    return min + r % (max - min);
+  }
+  float NextFloat() { return ((Next() << 15) + Next()) / ((float)(1 << 30)); }
+  float NextFloat(float valMin, float valMax) {
+    return valMin + (valMax - valMin) * NextFloat();
+  }
+  static int RandMax() { return 0x7fff; }
+};
+
+// World class to hold particles
+class World {
+public:
+  std::vector<Particle> particles;
+  std::vector<Particle> newParticles;
+
+  void generateRandom(int numParticles, float spaceSize) {
+    float maxVelocity = spaceSize * 0.5f;
+    Random random(3366);
+    particles.resize(numParticles);
+    newParticles.clear();
+    newParticles.resize(numParticles);
+
+    for (int i = 0; i < numParticles; i++) {
+      particles[i].mass = random.NextFloat(1.0f, 10.0f);
+      particles[i].velocity.x = random.NextFloat(-maxVelocity, maxVelocity);
+      particles[i].velocity.y = random.NextFloat(-maxVelocity, maxVelocity);
+      particles[i].position.x = random.NextFloat(-spaceSize, spaceSize);
+      particles[i].position.y = random.NextFloat(-spaceSize, spaceSize);
+      particles[i].id = i;
+    }
+  }
+};
+
+// Simulator interface - LLM solutions should implement this class
+// State can persist across simulateStep() calls
+class Simulator {
+public:
+  virtual ~Simulator() = default;
+  
+  // Called once before simulation starts
+  // Use this to set thread count, pre-allocate structures, etc.
+  virtual void init(int numParticles, StepParameters params) {}
+  
+  // Called each simulation step
+  // Must compute new particle positions/velocities and store in newParticles
+  virtual void simulateStep(std::vector<Particle> &particles,
+                            std::vector<Particle> &newParticles,
+                            StepParameters params) = 0;
+};
+
+// Factory function - solutions must implement this
+Simulator* createSimulator();
+
+#endif

--- a/research/problems/nbody_simulation/random_100k/config.yaml
+++ b/research/problems/nbody_simulation/random_100k/config.yaml
@@ -1,0 +1,11 @@
+dependencies:
+  uv_project: resources
+tag: hpc
+runtime:
+  timeout_seconds: 600
+  environment: "C++17 with OpenMP (GCC with libgomp1) on Ubuntu 22.04, 16 vCPUs"
+  resources:
+    cloud: aws
+    instance_type: c7i.4xlarge
+    cpus: "16"
+    memory: "32"

--- a/research/problems/nbody_simulation/random_100k/download_datasets.sh
+++ b/research/problems/nbody_simulation/random_100k/download_datasets.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# No external datasets needed - particles are generated dynamically
+echo "No external datasets required for N-body simulation."
+exit 0
+
+

--- a/research/problems/nbody_simulation/random_100k/evaluate.sh
+++ b/research/problems/nbody_simulation/random_100k/evaluate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+EXEC_ROOT="/work/execution_env"
+SOLUTION_PATH="$EXEC_ROOT/solution_env/solution.cpp"
+
+# Check if solution exists
+if [[ ! -f "$SOLUTION_PATH" ]]; then
+    echo "ERROR: solution.cpp not found at $SOLUTION_PATH" >&2
+    exit 1
+fi
+
+# Run the evaluator
+python3 evaluator.py --solution-path "$SOLUTION_PATH" --output-path ./result.json
+
+# Check if evaluation succeeded
+if [ ! -f "./result.json" ]; then
+    echo "Evaluation failed - no result file generated"
+    exit 1
+fi

--- a/research/problems/nbody_simulation/random_100k/evaluator.py
+++ b/research/problems/nbody_simulation/random_100k/evaluator.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Evaluator for N-body simulation problem (100k particles variant).
+
+Solutions are C++ files that implement Simulator class and createSimulator().
+"""
+
+import sys
+from pathlib import Path
+
+# Add common directory to path
+HERE = Path(__file__).resolve().parent
+COMMON_DIR = HERE.parent / "common"
+sys.path.insert(0, str(COMMON_DIR))
+
+from evaluator_common import VariantConfig, run_evaluator
+
+# Variant-specific configuration
+CONFIG = VariantConfig(
+    num_particles=100000,
+    num_iterations=3,  # Fewer iterations due to larger N
+    space_size=100.0,
+    num_runs=3,
+    min_speedup=1.0,   # 1x speedup = 0 points
+    max_speedup=7.5,  # 7.5x speedup = 100 points (Cursor with Opus 4.5 can achieve 6.05x with ~5 iterations)
+)
+
+DEFAULT_SPEC = HERE / "resources" / "submission_spec.json"
+
+if __name__ == "__main__":
+    run_evaluator(CONFIG, DEFAULT_SPEC)

--- a/research/problems/nbody_simulation/random_100k/readme
+++ b/research/problems/nbody_simulation/random_100k/readme
@@ -1,0 +1,260 @@
+N-Body Simulation Problem - 100,000 Particles
+=============================================
+
+Problem Setting
+---------------
+Design and optimize a high-performance parallel N-body simulation. In physics and astronomy, an N-body simulation models the dynamics of particles under gravitational forces. The available hardware is an AWS c7i.4xlarge.
+
+The challenge involves optimizing:
+- **Loop parallelization**: Efficient parallel force computation across particles
+- **Acceleration structures**: Use structures such as quad-tree for O(N log N) instead of O(N²), or other structures.
+- **Load balancing**: Handling varying workloads per particle
+- **Parallel Programming Libraries**: Proper use of libraries like OpenMP
+
+This variant tests performance on **100,000 particles** with 3 simulation iterations.
+
+Target
+------
+- **Primary**: Ensure numerical correctness (tolerance: 1e-2)
+- **Secondary**: Maximize speedup over parallel brute-force baseline (higher is better)
+- **Tertiary**: Use algorithmic improvements (quad-tree, spatial hashing) to beat O(N²)
+
+Solution Format
+---------------
+Submit a single C++ file (`.cpp`) that implements a `Simulator` class:
+
+```cpp
+#include "world.h"
+#include <omp.h>
+
+class MySimulator : public Simulator {
+private:
+    // Persistent state across simulation steps
+    int numThreads = 8;
+    // Could store acceleration structures, pre-allocated buffers, etc.
+
+public:
+    void init(int numParticles, StepParameters params) override {
+        // Called once before simulation starts
+        // Set thread count, pre-allocate structures, etc.
+        omp_set_num_threads(numThreads);
+    }
+
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        // Called each simulation step
+        // For each particle i:
+        //   1. Compute total force from particles within params.cullRadius
+        //   2. Update particle using updateParticle()
+        //   3. Store result in newParticles[i]
+    }
+};
+
+// Factory function - must be implemented
+Simulator* createSimulator() {
+    return new MySimulator();
+}
+```
+
+Provided Types and Functions (in world.h)
+-----------------------------------------
+```cpp
+struct Vec2 {
+    float x, y;
+    // Operators: +, -, *, length(), length2()
+};
+
+struct Particle {
+    int id;
+    float mass;
+    Vec2 position;
+    Vec2 velocity;
+};
+
+struct StepParameters {
+    float deltaTime = 0.2f;
+    float cullRadius = 1.0f;  // Only consider particles within this distance
+};
+
+// Simulator base class
+class Simulator {
+public:
+    virtual ~Simulator() = default;
+    virtual void init(int numParticles, StepParameters params) {}  // Optional
+    virtual void simulateStep(std::vector<Particle> &particles,
+                              std::vector<Particle> &newParticles,
+                              StepParameters params) = 0;  // Required
+};
+
+// Compute gravitational force between two particles
+// Returns Vec2(0,0) if distance > cullRadius or distance < 1e-3
+inline Vec2 computeForce(const Particle &target, const Particle &attractor,
+                         float cullRadius) {
+  auto dir = (attractor.position - target.position);
+  auto dist = dir.length();
+  if (dist < 1e-3f)
+    return Vec2(0.0f, 0.0f);
+  dir *= (1.0f / dist);
+  if (dist > cullRadius)
+    return Vec2(0.0f, 0.0f);
+  if (dist < 1e-1f)
+    dist = 1e-1f;
+  const float G = 0.01f;
+  Vec2 force = dir * target.mass * attractor.mass * (G / (dist * dist));
+  if (dist > cullRadius * 0.75f) {
+    float decay = 1.0f - (dist - cullRadius * 0.75f) / (cullRadius * 0.25f);
+    force *= decay;
+  }
+  return force;
+}
+
+// Apply force to particle and integrate position/velocity
+inline Particle updateParticle(const Particle &pi, Vec2 force,
+                               float deltaTime) {
+  Particle result = pi;
+  result.velocity += force * (deltaTime / pi.mass);
+  result.position += result.velocity * deltaTime;
+  return result;
+}
+```
+
+Baseline
+--------
+The baseline is a simple OpenMP parallel brute-force O(N²) implementation:
+
+```cpp
+// Baseline for N-body simulation - simple OpenMP parallel brute-force
+// O(N²) approach with parallel outer loop
+// Solutions should aim to beat this baseline
+
+#include "world.h"
+#include <omp.h>
+
+class BaselineSimulator : public Simulator {
+private:
+    int numThreads = 8;
+    
+public:
+    void init(int numParticles, StepParameters params) override {
+        omp_set_num_threads(numThreads);
+    }
+    
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        #pragma omp parallel for schedule(dynamic, 16)
+        for (int i = 0; i < (int)particles.size(); i++) {
+            auto pi = particles[i];
+            Vec2 force = Vec2(0.0f, 0.0f);
+            
+            for (size_t j = 0; j < particles.size(); j++) {
+                if (j == (size_t)i) continue;
+                if ((pi.position - particles[j].position).length() < params.cullRadius) {
+                    force += computeForce(pi, particles[j], params.cullRadius);
+                }
+            }
+            
+            newParticles[i] = updateParticle(pi, force, params.deltaTime);
+        }
+    }
+};
+
+Simulator* createSimulator() {
+    return new BaselineSimulator();
+}
+```
+
+To beat the baseline, use algorithmic improvements like acceleration structures.
+
+Please generate a `.cpp` file that follows the solution's interface above, with the exact same
+signatures. The `Simulator` you write will be used in the following way: 
+
+```cpp
+double runSimulation(World& world, Simulator* sim, 
+                     StepParameters params, int numIterations) {
+  Timer timer;
+  timer.reset();
+  
+  // Initialize simulator at the start of each run (clean state)
+  sim->init(world.particles.size(), params);
+  
+  for (int iter = 0; iter < numIterations; iter++) {
+    world.newParticles.resize(world.particles.size());
+    sim->simulateStep(world.particles, world.newParticles, params);
+    world.particles.swap(world.newParticles);
+  }
+  
+  return timer.elapsed();
+}
+```
+
+Compilation
+-----------
+Your code is compiled with:
+```bash
+g++ -O2 -fopenmp -std=c++17 -I. -o benchmark solution.cpp
+```
+
+Requirements:
+- Can use OpenMP for parallelization
+- Must implement a `Simulator` subclass and `createSimulator()` factory function
+- May define additional helper classes/functions as needed
+- Do NOT modify `computeForce` or `updateParticle` functions
+
+Correctness
+-----------
+
+We will use the `BaselineSimulator` to get a reference particles positions and compare the solution you generated with the following code. We use a tolerance of `1e-2f`. If you fail the correctness check, you will get a score of zero.
+
+```cpp
+bool checkForCorrectness(const World& refW, const World& w, float tolerance = 1e-2f) {
+  if (w.particles.size() != refW.particles.size()) {
+    std::cerr << "Mismatch: number of particles " << w.particles.size()
+              << " does not match reference " << refW.particles.size() << std::endl;
+    return false;
+  }
+
+  for (size_t i = 0; i < w.particles.size(); i++) {
+    auto errorX = std::abs(w.particles[i].position.x - refW.particles[i].position.x);
+    auto errorY = std::abs(w.particles[i].position.y - refW.particles[i].position.y);
+    if (errorX > tolerance || errorY > tolerance) {
+      std::cerr << "Mismatch at index " << i
+                << ": result (" << w.particles[i].position.x << ", "
+                << w.particles[i].position.y << ")"
+                << " should be (" << refW.particles[i].position.x << ", "
+                << refW.particles[i].position.y << ")" << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+Scoring (0-100)
+---------------
+Performance is measured by speedup over the parallel brute-force baseline:
+
+```
+speedup = baseline_time / solution_time
+raw_score = min(speedup, 10.0)  # Cap at 10x speedup
+score = (raw_score - 1.0) / 9.0 * 100  # Map 1x-10x to 0-100
+```
+
+- 0 points = No speedup (1x baseline performance)
+- ~11 points = 2x speedup
+- ~33 points = 4x speedup
+- ~56 points = 6x speedup
+- 100 points = 10x+ speedup
+
+Note: With 100k particles, algorithmic improvements can yield massive speedups.
+The brute-force baseline is extremely slow, so good solutions should achieve high speedups.
+
+Evaluation Details
+------------------
+- Tested with 100,000 particles
+- 3 simulation iterations
+- Space size: 100.0, cullRadius: 25.0
+- Performance measured as median of 3 runs
+- Correctness verified with tolerance: position error < 1e-2
+- Fixed random seed for reproducibility

--- a/research/problems/nbody_simulation/random_100k/resources/pyproject.toml
+++ b/research/problems/nbody_simulation/random_100k/resources/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "nbody-evaluator"
+version = "0.1.0"
+description = "Evaluator for N-body simulation problem"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+

--- a/research/problems/nbody_simulation/random_100k/run_evaluator.sh
+++ b/research/problems/nbody_simulation/random_100k/run_evaluator.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helper script to run evaluator locally for testing
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+SOLUTION_PATH="${1:-./solution.cpp}"
+
+python3 evaluator.py --solution-path "$SOLUTION_PATH" --output-path ./result.json

--- a/research/problems/nbody_simulation/random_10k/config.yaml
+++ b/research/problems/nbody_simulation/random_10k/config.yaml
@@ -1,0 +1,11 @@
+dependencies:
+  uv_project: resources
+tag: hpc
+runtime:
+  timeout_seconds: 600
+  environment: "C++17 with OpenMP (GCC with libgomp1) on Ubuntu 22.04, 16 vCPUs"
+  resources:
+    cloud: aws
+    instance_type: c7i.4xlarge
+    cpus: "16"
+    memory: "32"

--- a/research/problems/nbody_simulation/random_10k/download_datasets.sh
+++ b/research/problems/nbody_simulation/random_10k/download_datasets.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# No external datasets needed - particles are generated dynamically
+echo "No external datasets required for N-body simulation."
+exit 0
+
+

--- a/research/problems/nbody_simulation/random_10k/evaluate.sh
+++ b/research/problems/nbody_simulation/random_10k/evaluate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+EXEC_ROOT="/work/execution_env"
+SOLUTION_PATH="$EXEC_ROOT/solution_env/solution.cpp"
+
+# Check if solution exists
+if [[ ! -f "$SOLUTION_PATH" ]]; then
+    echo "ERROR: solution.cpp not found at $SOLUTION_PATH" >&2
+    exit 1
+fi
+
+# Run the evaluator
+python3 evaluator.py --solution-path "$SOLUTION_PATH" --output-path ./result.json
+
+# Check if evaluation succeeded
+if [ ! -f "./result.json" ]; then
+    echo "Evaluation failed - no result file generated"
+    exit 1
+fi

--- a/research/problems/nbody_simulation/random_10k/evaluator.py
+++ b/research/problems/nbody_simulation/random_10k/evaluator.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Evaluator for N-body simulation problem (10k particles variant).
+
+Solutions are C++ files that implement Simulator class and createSimulator().
+"""
+
+import sys
+from pathlib import Path
+
+# Add common directory to path
+HERE = Path(__file__).resolve().parent
+COMMON_DIR = HERE.parent / "common"
+sys.path.insert(0, str(COMMON_DIR))
+
+from evaluator_common import VariantConfig, run_evaluator
+
+# Variant-specific configuration
+CONFIG = VariantConfig(
+    num_particles=10000,
+    num_iterations=5,
+    space_size=100.0,
+    num_runs=3,
+    min_speedup=1.0,   # 1x speedup = 0 points
+    max_speedup=5.5,   # 5.5x speedup = 100 points (Cursor with Opus 4.5 can achieve 4.55x with ~5 iterations)
+)
+
+DEFAULT_SPEC = HERE / "resources" / "submission_spec.json"
+
+if __name__ == "__main__":
+    run_evaluator(CONFIG, DEFAULT_SPEC)

--- a/research/problems/nbody_simulation/random_10k/readme
+++ b/research/problems/nbody_simulation/random_10k/readme
@@ -1,0 +1,257 @@
+N-Body Simulation Problem - 10,000 Particles
+=============================================
+
+Problem Setting
+---------------
+Design and optimize a high-performance parallel N-body simulation. In physics and astronomy, an N-body simulation models the dynamics of particles under gravitational forces. The available hardware is an AWS c7i.4xlarge.
+
+The challenge involves optimizing:
+- **Loop parallelization**: Efficient parallel force computation across particles
+- **Acceleration structures**: Use structures such as quad-tree for O(N log N) instead of O(N²), or other structures.
+- **Load balancing**: Handling varying workloads per particle
+- **Parallel Programming Libraries**: Proper use of libraries like OpenMP
+
+This variant tests performance on **10,000 particles** with 5 simulation iterations.
+
+Target
+------
+- **Primary**: Ensure numerical correctness (tolerance: 1e-2)
+- **Secondary**: Maximize speedup over parallel brute-force baseline (higher is better)
+- **Tertiary**: Use algorithmic improvements (quad-tree, spatial hashing) to beat O(N²)
+
+Solution Format
+---------------
+Submit a single C++ file (`.cpp`) that implements a `Simulator` class:
+
+```cpp
+#include "world.h"
+#include <omp.h>
+
+class MySimulator : public Simulator {
+private:
+    // Persistent state across simulation steps
+    int numThreads = 8;
+    // Could store acceleration structures, pre-allocated buffers, etc.
+
+public:
+    void init(int numParticles, StepParameters params) override {
+        // Called once before simulation starts
+        // Set thread count, pre-allocate structures, etc.
+        omp_set_num_threads(numThreads);
+    }
+
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        // Called each simulation step
+        // For each particle i:
+        //   1. Compute total force from particles within params.cullRadius
+        //   2. Update particle using updateParticle()
+        //   3. Store result in newParticles[i]
+    }
+};
+
+// Factory function - must be implemented
+Simulator* createSimulator() {
+    return new MySimulator();
+}
+```
+
+Provided Types and Functions (in world.h)
+-----------------------------------------
+```cpp
+struct Vec2 {
+    float x, y;
+    // Operators: +, -, *, length(), length2()
+};
+
+struct Particle {
+    int id;
+    float mass;
+    Vec2 position;
+    Vec2 velocity;
+};
+
+struct StepParameters {
+    float deltaTime = 0.2f;
+    float cullRadius = 1.0f;  // Only consider particles within this distance
+};
+
+// Simulator base class
+class Simulator {
+public:
+    virtual ~Simulator() = default;
+    virtual void init(int numParticles, StepParameters params) {}  // Optional
+    virtual void simulateStep(std::vector<Particle> &particles,
+                              std::vector<Particle> &newParticles,
+                              StepParameters params) = 0;  // Required
+};
+
+// Compute gravitational force between two particles
+// Returns Vec2(0,0) if distance > cullRadius or distance < 1e-3
+inline Vec2 computeForce(const Particle &target, const Particle &attractor,
+                         float cullRadius) {
+  auto dir = (attractor.position - target.position);
+  auto dist = dir.length();
+  if (dist < 1e-3f)
+    return Vec2(0.0f, 0.0f);
+  dir *= (1.0f / dist);
+  if (dist > cullRadius)
+    return Vec2(0.0f, 0.0f);
+  if (dist < 1e-1f)
+    dist = 1e-1f;
+  const float G = 0.01f;
+  Vec2 force = dir * target.mass * attractor.mass * (G / (dist * dist));
+  if (dist > cullRadius * 0.75f) {
+    float decay = 1.0f - (dist - cullRadius * 0.75f) / (cullRadius * 0.25f);
+    force *= decay;
+  }
+  return force;
+}
+
+// Apply force to particle and integrate position/velocity
+inline Particle updateParticle(const Particle &pi, Vec2 force,
+                               float deltaTime) {
+  Particle result = pi;
+  result.velocity += force * (deltaTime / pi.mass);
+  result.position += result.velocity * deltaTime;
+  return result;
+}
+```
+
+Baseline
+--------
+The baseline is a simple OpenMP parallel brute-force O(N²) implementation:
+
+```cpp
+// Baseline for N-body simulation - simple OpenMP parallel brute-force
+// O(N²) approach with parallel outer loop
+// Solutions should aim to beat this baseline
+
+#include "world.h"
+#include <omp.h>
+
+class BaselineSimulator : public Simulator {
+private:
+    int numThreads = 8;
+    
+public:
+    void init(int numParticles, StepParameters params) override {
+        omp_set_num_threads(numThreads);
+    }
+    
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        #pragma omp parallel for schedule(dynamic, 16)
+        for (int i = 0; i < (int)particles.size(); i++) {
+            auto pi = particles[i];
+            Vec2 force = Vec2(0.0f, 0.0f);
+            
+            for (size_t j = 0; j < particles.size(); j++) {
+                if (j == (size_t)i) continue;
+                if ((pi.position - particles[j].position).length() < params.cullRadius) {
+                    force += computeForce(pi, particles[j], params.cullRadius);
+                }
+            }
+            
+            newParticles[i] = updateParticle(pi, force, params.deltaTime);
+        }
+    }
+};
+
+Simulator* createSimulator() {
+    return new BaselineSimulator();
+}
+```
+
+To beat the baseline, use algorithmic improvements like acceleration structures.
+
+Please generate a `.cpp` file that follows the solution's interface above, with the exact same
+signatures. The `Simulator` you write will be used in the following way: 
+
+```cpp
+double runSimulation(World& world, Simulator* sim, 
+                     StepParameters params, int numIterations) {
+  Timer timer;
+  timer.reset();
+  
+  // Initialize simulator at the start of each run (clean state)
+  sim->init(world.particles.size(), params);
+  
+  for (int iter = 0; iter < numIterations; iter++) {
+    world.newParticles.resize(world.particles.size());
+    sim->simulateStep(world.particles, world.newParticles, params);
+    world.particles.swap(world.newParticles);
+  }
+  
+  return timer.elapsed();
+}
+```
+
+Compilation
+-----------
+Your code is compiled with:
+```bash
+g++ -O2 -fopenmp -std=c++17 -I. -o benchmark solution.cpp
+```
+
+Requirements:
+- Can use OpenMP for parallelization
+- Must implement a `Simulator` subclass and `createSimulator()` factory function
+- May define additional helper classes/functions as needed
+- Do NOT modify `computeForce` or `updateParticle` functions
+
+Correctness
+-----------
+
+We will use the `BaselineSimulator` to get a reference particles positions and compare the solution you generated with the following code. We use a tolerance of `1e-2f`. If you fail the correctness check, you will get a score of zero.
+
+```cpp
+bool checkForCorrectness(const World& refW, const World& w, float tolerance = 1e-2f) {
+  if (w.particles.size() != refW.particles.size()) {
+    std::cerr << "Mismatch: number of particles " << w.particles.size()
+              << " does not match reference " << refW.particles.size() << std::endl;
+    return false;
+  }
+
+  for (size_t i = 0; i < w.particles.size(); i++) {
+    auto errorX = std::abs(w.particles[i].position.x - refW.particles[i].position.x);
+    auto errorY = std::abs(w.particles[i].position.y - refW.particles[i].position.y);
+    if (errorX > tolerance || errorY > tolerance) {
+      std::cerr << "Mismatch at index " << i
+                << ": result (" << w.particles[i].position.x << ", "
+                << w.particles[i].position.y << ")"
+                << " should be (" << refW.particles[i].position.x << ", "
+                << refW.particles[i].position.y << ")" << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+Scoring (0-100)
+---------------
+Performance is measured by speedup over the parallel brute-force baseline:
+
+```
+speedup = baseline_time / solution_time
+raw_score = min(speedup, 3.0)  # Cap at 3x speedup
+score = (raw_score - 1.0) / 2.0 * 100  # Map 1x-3x to 0-100
+```
+
+- 0 points = No speedup (1x baseline performance)
+- 50 points = 2x speedup
+- 100 points = 3x+ speedup
+
+Note: Since baseline is already parallelized, achieving speedup requires algorithmic improvements.
+
+Evaluation Details
+------------------
+- Tested with 10,000 particles
+- 5 simulation iterations
+- Space size: 100.0, cullRadius: 25.0
+- Performance measured as median of 3 runs
+- Correctness verified with tolerance: position error < 1e-2
+- Fixed random seed for reproducibility

--- a/research/problems/nbody_simulation/random_10k/resources/pyproject.toml
+++ b/research/problems/nbody_simulation/random_10k/resources/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "nbody-evaluator"
+version = "0.1.0"
+description = "Evaluator for N-body simulation problem"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+

--- a/research/problems/nbody_simulation/random_10k/run_evaluator.sh
+++ b/research/problems/nbody_simulation/random_10k/run_evaluator.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helper script to run evaluator locally for testing
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+SOLUTION_PATH="${1:-./solution.cpp}"
+
+python3 evaluator.py --solution-path "$SOLUTION_PATH" --output-path ./result.json

--- a/research/solutions/nbody_simulation/random_100k/reference_baseline.cpp
+++ b/research/solutions/nbody_simulation/random_100k/reference_baseline.cpp
@@ -1,0 +1,39 @@
+// Baseline for N-body simulation - simple OpenMP parallel brute-force
+// O(N²) approach with parallel outer loop
+// Solutions should aim to beat this baseline
+
+#include "world.h"
+#include <omp.h>
+
+class MySimulator : public Simulator {
+private:
+    int numThreads = 16;
+    
+public:
+    void init(int numParticles, StepParameters params) override {
+        omp_set_num_threads(numThreads);
+    }
+    
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        #pragma omp parallel for schedule(dynamic, 16)
+        for (int i = 0; i < (int)particles.size(); i++) {
+            auto pi = particles[i];
+            Vec2 force = Vec2(0.0f, 0.0f);
+            
+            for (size_t j = 0; j < particles.size(); j++) {
+                if (j == (size_t)i) continue;
+                if ((pi.position - particles[j].position).length() < params.cullRadius) {
+                    force += computeForce(pi, particles[j], params.cullRadius);
+                }
+            }
+            
+            newParticles[i] = updateParticle(pi, force, params.deltaTime);
+        }
+    }
+};
+
+Simulator* createSimulator() {
+    return new MySimulator();
+}

--- a/research/solutions/nbody_simulation/random_10k/reference_baseline.cpp
+++ b/research/solutions/nbody_simulation/random_10k/reference_baseline.cpp
@@ -1,0 +1,39 @@
+// Baseline for N-body simulation - simple OpenMP parallel brute-force
+// O(N²) approach with parallel outer loop
+// Solutions should aim to beat this baseline
+
+#include "world.h"
+#include <omp.h>
+
+class MySimulator : public Simulator {
+private:
+    int numThreads = 16;
+    
+public:
+    void init(int numParticles, StepParameters params) override {
+        omp_set_num_threads(numThreads);
+    }
+    
+    void simulateStep(std::vector<Particle> &particles,
+                      std::vector<Particle> &newParticles,
+                      StepParameters params) override {
+        #pragma omp parallel for schedule(dynamic, 16)
+        for (int i = 0; i < (int)particles.size(); i++) {
+            auto pi = particles[i];
+            Vec2 force = Vec2(0.0f, 0.0f);
+            
+            for (size_t j = 0; j < particles.size(); j++) {
+                if (j == (size_t)i) continue;
+                if ((pi.position - particles[j].position).length() < params.cullRadius) {
+                    force += computeForce(pi, particles[j], params.cullRadius);
+                }
+            }
+            
+            newParticles[i] = updateParticle(pi, force, params.deltaTime);
+        }
+    }
+};
+
+Simulator* createSimulator() {
+    return new MySimulator();
+}


### PR DESCRIPTION
We add a new problem of nbody simulation. There are two subproblems which only differ in the number of particles, 10k and 100k.

10k (5.5x speedup gives 100):
- human solution is 2.737x
- cursor-optimized with Opus 4.5 with 5 iterations is 4.55x

100k (7.5x speedup gives 100):
- human solution is 3.935x
- cursor-optimized with Opus 4.5 with 5 iterations is 6.049x

The above numbers are based on a c7i.4xlarge

The idea of the project is modeled after https://github.com/cmu15418f24/asst3 with modifications.

Testing done with:
- Be under either `random_10k/` or `random_100k/` and run `bash run_evaluator.sh /home/ubuntu/Frontier-CS/research/solutions/nbody_simulation/random_10k/reference_baseline.cpp`