### PR TITLE
fix: set unlimited stack ulimit for judge container

### DIFF
--- a/algorithmic/docker-compose.yml
+++ b/algorithmic/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     container_name: Competitive-Programming
     privileged: true              # Required by go-judge
     shm_size: "4g"                # Recommended >= 2G
+    ulimits:
+      stack:
+        soft: -1
+        hard: -1
     environment:
       PORT: "8081"                # Orchestrator API port
       GJ_ADDR: "http://127.0.0.1:5050"


### PR DESCRIPTION
## Summary
- Set stack ulimits to unlimited (`-1`) in `docker-compose.yml` for the judge container
- Fixes go-judge `setrlimit(RLIMIT_STACK): operation not permitted` error on Amazon Linux, where the default stack hard limit is 10MB — too low for the 256MB stack limit the judge requests
- No-op on macOS and Ubuntu where the default is already unlimited

## Test plan
- [x] Verified reference solution for problem 0 scores ~89 on Amazon Linux after fix
- [x] Confirmed `ulimit -Hs` inside container shows `unlimited`

🤖 Generated with [Claude Code](https://claude.com/claude-code)