### PR TITLE
fix: forward base_dir to AlgorithmicLocalRunner

### DIFF
--- a/src/frontier_cs/single_evaluator.py
+++ b/src/frontier_cs/single_evaluator.py
@@ -113,7 +113,10 @@ class SingleEvaluator:
     def algorithmic_runner(self) -> AlgorithmicLocalRunner:
         """Get or create the algorithmic runner."""
         if self._algorithmic_runner is None:
-            self._algorithmic_runner = AlgorithmicLocalRunner(judge_url=self.judge_url)
+            self._algorithmic_runner = AlgorithmicLocalRunner(
+                judge_url=self.judge_url,
+                base_dir=self.base_dir,
+            )
         return self._algorithmic_runner
 
     @property


### PR DESCRIPTION
# fix: forward `base_dir` to `AlgorithmicLocalRunner`

`SingleEvaluator` accepts `base_dir` in `__init__` and forwards it to the research/skypilot runners, but `algorithmic_runner` was instantiating `AlgorithmicLocalRunner` with only `judge_url`. As a result, `SingleEvaluator(base_dir=...).evaluate("algorithmic", ...)` silently ignored `base_dir` and fell back to `AlgorithmicLocalRunner._find_base_dir`, which walks up from the installed `.py` file — so when `frontier-cs` is installed as a package (e.g. `pip install .`), `base_dir` resolves to the site-packages lib dir and raises `algorithmic/ not found in ...`.

Forwarding `base_dir` alongside `judge_url` brings this property in line with the other three runner properties.

**Repro**: clone the repo to any location, `pip install .`, then from any unrelated cwd: `SingleEvaluator(base_dir=Path("/your/clone")).evaluate("algorithmic", "0", "// stub")` → `RuntimeError: algorithmic/ not found in <site-packages path>`. After this fix it returns a valid `EvaluationResult`.
