### PR TITLE
Add async submissions for Frontier-CS 2.0 Harbor tasks

### DIFF
--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/adapter.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/adapter.py
@@ -144,21 +144,25 @@ class FrontierCS20Adapter:
         if submission_kind == "directory":
             workflow = (
                 "Create or modify the project under `/app`. You can call "
-                "`bash /app/submit.sh` at any time to package `/app`, grade it "
-                "with the same black-box judge used by the final verifier, and "
-                "get score feedback. The evaluator implementation and hidden "
+                "`bash /app/submit.sh` at any time to package a snapshot of `/app` "
+                "and enqueue it for the same black-box judge used by the final "
+                "verifier. Submissions are asynchronous: use "
+                "`bash /app/submissions.sh` and `bash /app/wait_submission.sh <uuid>` "
+                "to inspect results. The evaluator implementation and hidden "
                 "benchmark data are intentionally not available in the agent "
-                "workspace. The task statement defines the required build and "
-                "runtime contract.\n\n"
+                "workspace. Read `AGENT.md` for the shared submission workflow. "
+                "The task statement defines the required build and runtime contract.\n\n"
                 f"Final submission path: `{submission_path}`\n"
             )
         else:
             workflow = (
                 f"Create a {problem.language} solution at `{submission_path}`. "
-                "You can call `bash /app/submit.sh` at any time to grade the "
-                "current solution with the same black-box judge used by the final "
-                "verifier and get score feedback. The evaluator implementation is "
-                "intentionally not available in the agent workspace.\n"
+                "You can call `bash /app/submit.sh` at any time to enqueue a "
+                "snapshot for the same black-box judge used by the final verifier. "
+                "Submissions are asynchronous: use `bash /app/submissions.sh` and "
+                "`bash /app/wait_submission.sh <uuid>` to inspect results. The "
+                "evaluator implementation is intentionally not available in the "
+                "agent workspace. Read `AGENT.md` for the shared submission workflow.\n"
             )
 
         instruction = (
@@ -221,6 +225,9 @@ class FrontierCS20Adapter:
             src = problem.problem_dir / name
             if src.exists():
                 shutil.copy2(src, env_dir / name)
+        (env_dir / "task_config.json").write_text(
+            json.dumps(problem.config, indent=2), encoding="utf-8"
+        )
         self._write_submission_config(env_dir, problem)
         harbor_app_dir = problem.problem_dir / "harbor" / "app"
         generated_harbor_app_dir = env_dir / "harbor_app"
@@ -263,15 +270,26 @@ class FrontierCS20Adapter:
             judge_server.replace("{verifier_token}", verifier_token),
             encoding="utf-8",
         )
-        shutil.copy2(
-            self.template_dir / "environment" / "submit.py", env_dir / "submit.py"
-        )
+        for name in (
+            "AGENT.md",
+            "submit.py",
+            "submissions.py",
+            "wait_submission.py",
+            "cancel_submission.py",
+        ):
+            shutil.copy2(self.template_dir / "environment" / name, env_dir / name)
         # Kept in the build context for the judge image only; the main agent
         # image's Dockerfile does not copy this into /app.
         shutil.copy2(problem.problem_dir / "evaluator.py", env_dir / "problem_evaluator.py")
-        submit_sh = env_dir / "submit.sh"
-        shutil.copy2(self.template_dir / "environment" / "submit.sh", submit_sh)
-        submit_sh.chmod(0o755)
+        for name in (
+            "submit.sh",
+            "submissions.sh",
+            "wait_submission.sh",
+            "cancel_submission.sh",
+        ):
+            script = env_dir / name
+            shutil.copy2(self.template_dir / "environment" / name, script)
+            script.chmod(0o755)
 
     def _write_submission_config(self, env_dir: Path, problem: FrontierCS20Problem) -> None:
         submission = dict(problem.config.get("submission", {}) or {})

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/AGENT.md
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/AGENT.md
@@ -1,0 +1,22 @@
+# Frontier-CS 2.0 Submission Workflow
+
+Submissions are asynchronous. `bash /app/submit.sh` snapshots the current solution,
+adds it to the judge queue, and returns immediately with a submission UUID.
+
+Useful commands:
+
+```bash
+bash /app/submit.sh
+bash /app/submissions.sh
+bash /app/wait_submission.sh <submission_uuid>
+bash /app/cancel_submission.sh <submission_uuid>
+```
+
+The judge evaluates one queued submission at a time. Continue improving your
+solution while a queued or running submission is being scored. Cancel only works
+for submissions that have not started running. The queue accepts a small number
+of queued/running submissions at once; if it is full, wait for an existing
+submission to finish or cancel a queued one.
+
+The final verifier can reuse the best completed iterative submission, so submit
+early and often enough to get feedback, but avoid flooding the queue.

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/Dockerfile
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/Dockerfile
@@ -25,6 +25,8 @@ ENV CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000
 
 WORKDIR /app
 
-COPY readme config.yaml submission_config.json submit.py submit.sh /app/
+COPY readme config.yaml task_config.json submission_config.json AGENT.md \
+    submit.py submit.sh submissions.py submissions.sh \
+    wait_submission.py wait_submission.sh cancel_submission.py cancel_submission.sh /app/
 COPY harbor_app/ /app/
-RUN chmod +x /app/submit.sh
+RUN chmod +x /app/submit.sh /app/submissions.sh /app/wait_submission.sh /app/cancel_submission.sh

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/Dockerfile.judge
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/Dockerfile.judge
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 WORKDIR /judge
 
-COPY judge_server.py problem_evaluator.py /judge/
+COPY judge_server.py problem_evaluator.py task_config.json /judge/
 RUN chmod 600 /judge/problem_evaluator.py
 
 EXPOSE 8082

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/cancel_submission.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/cancel_submission.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Cancel a queued Frontier-CS 2.0 async submission."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import requests
+
+JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("submission_uuid")
+    parser.add_argument("--json", action="store_true", help="print raw JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    response = requests.post(
+        f"{JUDGE_URL}/submission/{args.submission_uuid}/cancel",
+        json={},
+        timeout=10,
+    )
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {"status": "error", "error": response.text}
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    elif response.status_code == 200:
+        print(f"[cancel] uuid={args.submission_uuid} status=cancelled")
+    else:
+        print(f"[cancel] failed: {payload}", file=sys.stderr)
+    return 0 if response.status_code == 200 else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/cancel_submission.sh
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/cancel_submission.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 /app/cancel_submission.py "$@"

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/judge_server.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/judge_server.py
@@ -15,17 +15,60 @@ import time
 import traceback
 import threading
 import secrets
+from collections import deque
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 PROBLEM_EVALUATOR_PATH = Path("/judge/problem_evaluator.py")
+TASK_CONFIG_PATH = Path("/judge/task_config.json")
 JUDGE_READY_LOG = Path("/logs/judge/judge_ready.json")
 JUDGE_SUBMISSIONS_LOG = Path("/logs/judge/submissions.jsonl")
+BEST_SUBMISSION_PAYLOAD = Path("/logs/judge/best_submission_payload.json")
+BEST_SUBMISSION_META = Path("/logs/judge/best_submission_meta.json")
 MAX_SUBMISSION_BYTES = 30_000_000
 MAX_ARCHIVE_BYTES = 20_000_000
 FINAL_ROLE_TOKEN = "{verifier_token}"
+DEFAULT_MAX_QUEUE_SIZE = 3
+EVALUATION_LOCK_TIMEOUT_SECONDS = int(
+    os.environ.get("JUDGE_TIMEOUT_SECONDS", "10800")
+)
+
+
+def load_task_config() -> dict[str, Any]:
+    if not TASK_CONFIG_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(TASK_CONFIG_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def configured_max_queue_size() -> int:
+    env_value = os.environ.get("FRONTIER_MAX_ASYNC_SUBMISSIONS")
+    if env_value:
+        try:
+            return max(1, int(env_value))
+        except ValueError:
+            pass
+    config = load_task_config()
+    submission = config.get("submission", {})
+    if isinstance(submission, dict):
+        for key in ("max_queue_size", "queue_size"):
+            value = submission.get(key)
+            if value is None:
+                continue
+            try:
+                return max(1, int(value))
+            except (TypeError, ValueError):
+                continue
+    return DEFAULT_MAX_QUEUE_SIZE
+
+
+MAX_QUEUE_SIZE = configured_max_queue_size()
 
 
 def load_problem_evaluator():
@@ -43,6 +86,13 @@ def load_problem_evaluator():
 EVALUATOR = None
 READY = False
 READY_PAYLOAD: dict[str, Any] = {"status": "starting"}
+SUBMISSION_LOCK = threading.RLock()
+SUBMISSION_CONDITION = threading.Condition(SUBMISSION_LOCK)
+SUBMISSION_QUEUE: deque[str] = deque()
+SUBMISSION_PAYLOADS: dict[str, dict[str, Any]] = {}
+SUBMISSION_RECORDS: dict[str, dict[str, Any]] = {}
+SUBMISSION_ORDER: list[str] = []
+EVALUATION_LOCK = threading.Lock()
 
 
 def now_iso() -> str:
@@ -67,6 +117,26 @@ def log_submission(record: dict[str, Any]) -> None:
         f.write(json.dumps({"ts": now_iso(), **record}, ensure_ascii=False) + "\n")
 
 
+def update_submission_record(submission_uuid: str, record: dict[str, Any]) -> dict[str, Any]:
+    with SUBMISSION_LOCK:
+        previous = SUBMISSION_RECORDS.get(submission_uuid, {})
+        merged = {**previous, **record, "submission_uuid": submission_uuid}
+        SUBMISSION_RECORDS[submission_uuid] = merged
+        if submission_uuid not in SUBMISSION_ORDER:
+            SUBMISSION_ORDER.append(submission_uuid)
+    log_submission(merged)
+    return merged
+
+
+def latest_submissions() -> list[dict[str, Any]]:
+    with SUBMISSION_LOCK:
+        return [
+            dict(SUBMISSION_RECORDS[submission_uuid])
+            for submission_uuid in SUBMISSION_ORDER
+            if submission_uuid in SUBMISSION_RECORDS
+        ]
+
+
 def read_submissions() -> list[dict[str, Any]]:
     if not JUDGE_SUBMISSIONS_LOG.exists():
         return []
@@ -81,6 +151,46 @@ def read_submissions() -> list[dict[str, Any]]:
         if isinstance(record, dict):
             records.append(record)
     return records
+
+
+def best_score_key_from_meta(path: Path) -> tuple[float, float] | None:
+    if not path.exists():
+        return None
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+        score = float(metadata.get("score_raw", 0.0))
+        return (score, float(metadata.get("score_unbounded", score)))
+    except Exception:
+        return None
+
+
+def save_best_submission(payload: dict[str, Any], record: dict[str, Any]) -> None:
+    if record.get("status") != "done":
+        return
+    try:
+        score = float(record.get("score", 0.0))
+        score_unbounded = float(record.get("score_unbounded", score))
+    except (TypeError, ValueError):
+        return
+
+    score_key = (score, score_unbounded)
+    previous_key = best_score_key_from_meta(BEST_SUBMISSION_META)
+    if previous_key is not None and score_key <= previous_key:
+        return
+
+    metadata = {
+        "submission_uuid": record.get("submission_uuid"),
+        "ts": record.get("ts") or now_iso(),
+        "score_raw": score,
+        "score_unbounded": score_unbounded,
+        "detail": record.get("message", ""),
+        "metrics": record.get("metrics", {}),
+    }
+    BEST_SUBMISSION_PAYLOAD.parent.mkdir(parents=True, exist_ok=True)
+    BEST_SUBMISSION_PAYLOAD.write_text(json.dumps(payload), encoding="utf-8")
+    BEST_SUBMISSION_META.write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
 
 
 def prepare_evaluator() -> None:
@@ -181,6 +291,108 @@ def evaluate_archive(archive_b64: str, *, submission_role: str = "agent") -> dic
         return evaluate_path(root, submission_role=submission_role)
 
 
+def validate_payload(payload: dict[str, Any], *, allow_final: bool, role_token: str = "") -> tuple[str, str, str]:
+    submission_uuid = str(payload.get("submission_uuid") or "")
+    if not submission_uuid:
+        raise ValueError("submission_uuid is required")
+
+    requested_role = str(payload.get("submission_role") or "agent")
+    if requested_role == "final":
+        if not allow_final or not secrets.compare_digest(role_token, FINAL_ROLE_TOKEN):
+            raise PermissionError("final evaluation role is verifier-only")
+        submission_role = "final"
+    else:
+        submission_role = "agent"
+
+    submission_kind = str(payload.get("submission_kind", "file"))
+    if submission_kind == "directory":
+        archive_b64 = payload.get("archive_b64")
+        if not isinstance(archive_b64, str) or not archive_b64:
+            raise ValueError("directory submission must include archive_b64")
+    else:
+        code = payload.get("code")
+        if not isinstance(code, str) or not code.strip():
+            raise ValueError("file submission must include non-empty string field 'code'")
+        submission_kind = "file"
+    return submission_uuid, submission_role, submission_kind
+
+
+def run_payload(payload: dict[str, Any], *, submission_role: str) -> dict[str, Any]:
+    acquired = EVALUATION_LOCK.acquire(timeout=EVALUATION_LOCK_TIMEOUT_SECONDS)
+    if not acquired:
+        raise TimeoutError("timed out waiting for evaluator lock")
+    try:
+        submission_kind = str(payload.get("submission_kind", "file"))
+        if submission_kind == "directory":
+            return evaluate_archive(str(payload.get("archive_b64")), submission_role=submission_role)
+        return evaluate_code(str(payload.get("code")), submission_role=submission_role)
+    finally:
+        EVALUATION_LOCK.release()
+
+
+def queue_size() -> int:
+    return sum(
+        1
+        for record in SUBMISSION_RECORDS.values()
+        if record.get("status") in {"queued", "running"}
+    )
+
+
+def submission_worker() -> None:
+    while True:
+        with SUBMISSION_CONDITION:
+            while True:
+                while SUBMISSION_QUEUE:
+                    submission_uuid = SUBMISSION_QUEUE.popleft()
+                    record = SUBMISSION_RECORDS.get(submission_uuid, {})
+                    if record.get("status") == "queued":
+                        break
+                else:
+                    SUBMISSION_CONDITION.wait()
+                    continue
+                break
+
+        payload = SUBMISSION_PAYLOADS.get(submission_uuid)
+        if payload is None:
+            update_submission_record(
+                submission_uuid,
+                {"status": "error", "message": "queued payload is missing"},
+            )
+            continue
+
+        update_submission_record(submission_uuid, {"status": "running"})
+        started = time.time()
+        try:
+            result = run_payload(payload, submission_role="agent")
+            elapsed = time.time() - started
+            record = update_submission_record(
+                submission_uuid,
+                {
+                    "status": result.get("status", "done"),
+                    "score": float(result.get("score", 0.0)),
+                    "score_unbounded": float(result.get("score_unbounded", 0.0)),
+                    "message": str(result.get("message", "")),
+                    "metrics": result.get("metrics", {}),
+                    "elapsed_seconds": elapsed,
+                },
+            )
+            save_best_submission(payload, record)
+        except Exception:
+            detail = traceback.format_exc()
+            print(detail, flush=True)
+            update_submission_record(
+                submission_uuid,
+                {
+                    "status": "error",
+                    "score": 0.0,
+                    "score_unbounded": 0.0,
+                    "message": "evaluation failed",
+                    "detail": detail,
+                    "elapsed_seconds": time.time() - started,
+                },
+            )
+
+
 class JudgeHandler(BaseHTTPRequestHandler):
     server_version = "FrontierCS20Judge/1.0"
 
@@ -193,16 +405,34 @@ class JudgeHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self) -> None:
-        if self.path == "/health":
+        parsed = urlparse(self.path)
+        if parsed.path == "/health":
             self._write_json(200 if READY else 503, READY_PAYLOAD)
             return
-        if self.path == "/submissions":
-            self._write_json(200, {"status": "ok", "submissions": read_submissions()})
+        if parsed.path == "/submissions":
+            self._write_json(200, {"status": "ok", "submissions": latest_submissions()})
+            return
+        if parsed.path.startswith("/submission/"):
+            submission_uuid = parsed.path.removeprefix("/submission/").strip("/")
+            with SUBMISSION_LOCK:
+                record = SUBMISSION_RECORDS.get(submission_uuid)
+            if record is None:
+                self._write_json(404, {"status": "error", "error": "submission not found"})
+            else:
+                self._write_json(200, {"status": "ok", "submission": record})
             return
         self._write_json(404, {"status": "error", "error": "not found"})
 
     def do_POST(self) -> None:
-        if self.path != "/evaluate":
+        parsed = urlparse(self.path)
+        if parsed.path == "/submit":
+            self.handle_submit()
+            return
+        if parsed.path.startswith("/submission/") and parsed.path.endswith("/cancel"):
+            submission_uuid = parsed.path.removeprefix("/submission/").removesuffix("/cancel").strip("/")
+            self.handle_cancel(submission_uuid)
+            return
+        if parsed.path != "/evaluate":
             self._write_json(404, {"status": "error", "error": "not found"})
             return
         if not READY:
@@ -236,39 +466,12 @@ class JudgeHandler(BaseHTTPRequestHandler):
         submission_kind = "file"
         try:
             payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
-            submission_uuid = str(payload.get("submission_uuid") or "")
-            requested_role = str(payload.get("submission_role") or "agent")
-            role_token = self.headers.get("X-Frontier-CS-Role-Token", "")
-            if requested_role == "final":
-                if not secrets.compare_digest(role_token, FINAL_ROLE_TOKEN):
-                    raise PermissionError("final evaluation role is verifier-only")
-                submission_role = "final"
-            else:
-                submission_role = "agent"
-            submission_kind = payload.get("submission_kind", "file")
-            if submission_kind == "directory":
-                archive_b64 = payload.get("archive_b64")
-                if not isinstance(archive_b64, str) or not archive_b64:
-                    raise ValueError(
-                        "directory submission must include archive_b64"
-                    )
-                result = evaluate_archive(archive_b64, submission_role=submission_role)
-                log_submission(
-                    {
-                        "submission_uuid": submission_uuid,
-                        "submission_role": submission_role,
-                        "submission_kind": submission_kind,
-                        **result,
-                    }
-                )
-                self._write_json(200, result)
-                return
-            code = payload.get("code")
-            if not isinstance(code, str) or not code.strip():
-                raise ValueError(
-                    "file submission must include non-empty string field 'code'"
-                )
-            result = evaluate_code(code, submission_role=submission_role)
+            submission_uuid, submission_role, submission_kind = validate_payload(
+                payload,
+                allow_final=True,
+                role_token=self.headers.get("X-Frontier-CS-Role-Token", ""),
+            )
+            result = run_payload(payload, submission_role=submission_role)
             log_submission(
                 {
                     "submission_uuid": submission_uuid,
@@ -296,6 +499,93 @@ class JudgeHandler(BaseHTTPRequestHandler):
             )
             self._write_json(200, result)
 
+    def read_json_body(self) -> dict[str, Any]:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError as exc:
+            raise ValueError("invalid content length") from exc
+        if content_length <= 0:
+            raise ValueError("empty request body")
+        if content_length > MAX_SUBMISSION_BYTES:
+            raise ValueError("submission too large")
+        payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be a JSON object")
+        return payload
+
+    def handle_submit(self) -> None:
+        if not READY:
+            self._write_json(503, {"status": "error", "error": "judge is not ready", "health": READY_PAYLOAD})
+            return
+        try:
+            payload = self.read_json_body()
+            submission_uuid, submission_role, submission_kind = validate_payload(
+                payload,
+                allow_final=False,
+            )
+            if submission_role != "agent":
+                raise PermissionError("async submissions are agent-only")
+            with SUBMISSION_CONDITION:
+                if queue_size() >= MAX_QUEUE_SIZE:
+                    self._write_json(
+                        429,
+                        {
+                            "status": "error",
+                            "error": f"too many queued/running submissions; limit={MAX_QUEUE_SIZE}",
+                        },
+                    )
+                    return
+                if submission_uuid in SUBMISSION_RECORDS:
+                    raise ValueError("duplicate submission_uuid")
+                SUBMISSION_PAYLOADS[submission_uuid] = dict(payload)
+                SUBMISSION_QUEUE.append(submission_uuid)
+                position = len(SUBMISSION_QUEUE)
+                update_submission_record(
+                    submission_uuid,
+                    {
+                        "submission_role": "agent",
+                        "submission_kind": submission_kind,
+                        "status": "queued",
+                        "code_chars": payload.get("code_chars"),
+                        "file_count": payload.get("file_count"),
+                        "solution_path": payload.get("solution_path"),
+                        "queue_position": position,
+                    },
+                )
+                SUBMISSION_CONDITION.notify()
+            self._write_json(
+                202,
+                {
+                    "status": "queued",
+                    "submission_uuid": submission_uuid,
+                    "queue_position": position,
+                },
+            )
+        except Exception as exc:
+            print(traceback.format_exc(), flush=True)
+            self._write_json(400, {"status": "error", "error": str(exc)})
+
+    def handle_cancel(self, submission_uuid: str) -> None:
+        with SUBMISSION_CONDITION:
+            record = SUBMISSION_RECORDS.get(submission_uuid)
+            if record is None:
+                self._write_json(404, {"status": "error", "error": "submission not found"})
+                return
+            if record.get("status") != "queued":
+                self._write_json(
+                    409,
+                    {
+                        "status": "error",
+                        "error": "only queued submissions can be cancelled",
+                        "submission": record,
+                    },
+                )
+                return
+            update_submission_record(submission_uuid, {"status": "cancelled"})
+            SUBMISSION_PAYLOADS.pop(submission_uuid, None)
+            SUBMISSION_CONDITION.notify()
+        self._write_json(200, {"status": "cancelled", "submission_uuid": submission_uuid})
+
     def log_message(self, fmt: str, *args: object) -> None:
         return
 
@@ -304,6 +594,7 @@ def main() -> None:
     port = int(os.environ.get("PORT", "8082"))
     server = ThreadingHTTPServer(("0.0.0.0", port), JudgeHandler)
     threading.Thread(target=prepare_evaluator, daemon=True).start()
+    threading.Thread(target=submission_worker, daemon=True).start()
     server.serve_forever()
 
 

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submissions.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submissions.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""List Frontier-CS 2.0 async submissions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print raw JSON")
+    return parser.parse_args()
+
+
+def score_text(record: dict) -> str:
+    if record.get("status") != "done":
+        return "-"
+    try:
+        return f"{float(record.get('score', 0.0)):.2f}"
+    except (TypeError, ValueError):
+        return "-"
+
+
+def main() -> int:
+    args = parse_args()
+    response = requests.get(f"{JUDGE_URL}/submissions", timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    submissions = payload.get("submissions", [])
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+    if not submissions:
+        print("No submissions yet.")
+        return 0
+    print("uuid                                  status     score    code_chars  submitted_at")
+    for record in submissions:
+        if not isinstance(record, dict):
+            continue
+        uuid = str(record.get("submission_uuid", ""))[:36]
+        status = str(record.get("status", "unknown"))[:10]
+        code_chars = record.get("code_chars")
+        code_text = str(code_chars) if code_chars is not None else "-"
+        timestamp = record.get("ts") or datetime.now(timezone.utc).isoformat()
+        print(f"{uuid:36}  {status:10} {score_text(record):>7} {code_text:>11}  {timestamp}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submissions.sh
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submissions.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 /app/submissions.py "$@"

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submit.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/submit.py
@@ -12,6 +12,7 @@ import uuid
 import base64
 import io
 import tarfile
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -44,32 +45,6 @@ def log_record(record: dict) -> None:
     SUBMISSIONS_LOG.parent.mkdir(parents=True, exist_ok=True)
     with SUBMISSIONS_LOG.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
-
-
-def save_best_submission(payload: dict, metadata: dict) -> None:
-    previous_key: tuple[float, float] | None = None
-    if BEST_SUBMISSION_META.exists():
-        try:
-            previous = json.loads(BEST_SUBMISSION_META.read_text(encoding="utf-8"))
-            previous_score = float(previous.get("score_raw", 0.0))
-            previous_unbounded = float(
-                previous.get("score_unbounded", previous_score)
-            )
-            previous_key = (previous_score, previous_unbounded)
-        except Exception:
-            previous_key = None
-
-    score_raw = float(metadata.get("score_raw", 0.0))
-    score_unbounded = float(metadata.get("score_unbounded", score_raw))
-    score_key = (score_raw, score_unbounded)
-    if previous_key is not None and score_key <= previous_key:
-        return
-
-    BEST_SUBMISSION_PAYLOAD.parent.mkdir(parents=True, exist_ok=True)
-    BEST_SUBMISSION_PAYLOAD.write_text(json.dumps(payload), encoding="utf-8")
-    BEST_SUBMISSION_META.write_text(
-        json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8"
-    )
 
 
 def wait_for_judge() -> None:
@@ -134,18 +109,37 @@ def make_directory_archive(root: Path, exclude: list[str]) -> tuple[str, int]:
     return base64.b64encode(buf.getvalue()).decode("ascii"), file_count
 
 
-def evaluate_with_judge(payload: dict) -> dict:
+def enqueue_with_judge(payload: dict) -> dict:
     wait_for_judge()
     response = requests.post(
-        f"{JUDGE_URL}/evaluate",
+        f"{JUDGE_URL}/submit",
         json=payload,
-        timeout=JUDGE_TIMEOUT_SECONDS,
+        timeout=30,
     )
     response.raise_for_status()
-    payload = response.json()
-    if payload.get("status") != "done":
-        raise RuntimeError(str(payload.get("message") or payload.get("error") or payload))
-    return payload
+    result = response.json()
+    if result.get("status") != "queued":
+        raise RuntimeError(str(result.get("message") or result.get("error") or result))
+    return result
+
+
+def start_submission_watcher(submission_uuid: str) -> None:
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                "/app/wait_submission.py",
+                submission_uuid,
+                "--log-agent",
+                "--quiet",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:
+        print(f"[submit] WARN: failed to start async watcher: {exc}", file=sys.stderr)
 
 
 def main() -> int:
@@ -207,6 +201,9 @@ def main() -> int:
             "submission_uuid": sub_uuid,
             "submission_role": "agent",
             "archive_b64": archive_b64,
+            "solution_path": str(solution_path),
+            "code_chars": code_chars,
+            "file_count": file_count,
         }
     else:
         code = solution_path.read_text(encoding="utf-8")
@@ -229,61 +226,34 @@ def main() -> int:
             "submission_uuid": sub_uuid,
             "submission_role": "agent",
             "code": code,
+            "solution_path": str(solution_path),
+            "code_chars": code_chars,
+            "file_count": file_count,
         }
 
     try:
-        start = time.time()
-        judge_result = evaluate_with_judge(judge_payload)
-        score = float(judge_result.get("score", 0.0))
-        score_unbounded = float(judge_result.get("score_unbounded", score))
-        message = str(judge_result.get("message", ""))
-        metrics = dict(judge_result.get("metrics", {}) or {})
-        elapsed_seconds = time.time() - start
-        reward = float(score) / 100.0
-
+        judge_result = enqueue_with_judge(judge_payload)
         log_record(
             {
                 "submission_uuid": sub_uuid,
                 "ts": now_iso(),
-                "status": "done",
-                "score": reward,
-                "score_raw": score,
-                "score_unbounded": score_unbounded,
-                "elapsed_seconds": elapsed_seconds,
-                "detail": message,
+                "status": "queued",
                 "code_chars": code_chars,
                 "file_count": file_count,
-                "metrics": metrics,
+                "queue_position": judge_result.get("queue_position"),
             }
         )
-        save_best_submission(
-            judge_payload,
-            {
-                "submission_uuid": sub_uuid,
-                "ts": now_iso(),
-                "score_raw": score,
-                "score_unbounded": score_unbounded,
-                "elapsed_seconds": elapsed_seconds,
-                "detail": message,
-                "metrics": metrics,
-            },
-        )
+        start_submission_watcher(sub_uuid)
 
         print(f"[submit] uuid={sub_uuid}")
         print(
-            f"[submit] status=done score={reward:.4f} "
-            f"(raw={score}/100) code_chars={code_chars}"
+            f"[submit] status=queued queue_position={judge_result.get('queue_position')} "
+            f"code_chars={code_chars}"
         )
-        if score_unbounded != score:
-            print(f"[submit] unbounded={score_unbounded}")
-        if message:
-            snippet = message if len(message) <= 800 else message[:800] + "..."
-            print(f"[submit] detail: {snippet}")
-        if metrics:
-            metric_text = " ".join(
-                f"{key}={value}" for key, value in sorted(metrics.items())
-            )
-            print(f"[submit] metrics: {metric_text}")
+        print("[submit] async submission accepted; continue improving while it runs")
+        print(f"[submit] wait: bash /app/wait_submission.sh {sub_uuid}")
+        print("[submit] list: bash /app/submissions.sh")
+        print(f"[submit] cancel queued: bash /app/cancel_submission.sh {sub_uuid}")
         return 0
     except Exception as exc:
         detail = traceback.format_exc()

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/wait_submission.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/wait_submission.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Wait for one Frontier-CS 2.0 async submission."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
+SUBMISSIONS_LOG = Path("/logs/agent/submissions.jsonl")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("submission_uuid")
+    parser.add_argument("--timeout", type=float, default=0.0, help="seconds; 0 means wait forever")
+    parser.add_argument("--json", action="store_true", help="print raw JSON result")
+    parser.add_argument("--log-agent", action="store_true", help="mirror status changes to /logs/agent/submissions.jsonl")
+    parser.add_argument("--quiet", action="store_true", help="suppress progress text")
+    return parser.parse_args()
+
+
+def now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def log_agent_record(record: dict) -> None:
+    payload = dict(record)
+    payload.setdefault("ts", now_iso())
+    SUBMISSIONS_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with SUBMISSIONS_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def fetch(submission_uuid: str) -> dict:
+    response = requests.get(f"{JUDGE_URL}/submission/{submission_uuid}", timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    submission = payload.get("submission")
+    if not isinstance(submission, dict):
+        raise RuntimeError(str(payload))
+    return submission
+
+
+def print_result(record: dict, *, raw_json: bool) -> None:
+    if raw_json:
+        print(json.dumps(record, indent=2, ensure_ascii=False))
+        return
+    status = record.get("status")
+    print(f"[wait] uuid={record.get('submission_uuid')} status={status}")
+    if status == "done":
+        score = float(record.get("score", 0.0))
+        reward = score / 100.0
+        print(f"[wait] score={score:.4f}/100 reward={reward:.4f}")
+        if record.get("score_unbounded") != score:
+            print(f"[wait] unbounded={record.get('score_unbounded')}")
+        message = str(record.get("message", ""))
+        if message:
+            print(f"[wait] detail: {message[:800]}")
+        metrics = record.get("metrics", {})
+        if isinstance(metrics, dict) and metrics:
+            metric_text = " ".join(f"{key}={value}" for key, value in sorted(metrics.items()))
+            print(f"[wait] metrics: {metric_text}")
+
+
+def main() -> int:
+    args = parse_args()
+    deadline = time.time() + args.timeout if args.timeout > 0 else None
+    last_status: str | None = None
+    while True:
+        record = fetch(args.submission_uuid)
+        status = str(record.get("status", "unknown"))
+        if status != last_status:
+            if args.log_agent:
+                log_agent_record(record)
+            if not args.json and not args.quiet:
+                print(f"[wait] status={status}", flush=True)
+            last_status = status
+        if status in {"done", "error", "cancelled"}:
+            if not args.quiet:
+                print_result(record, raw_json=args.json)
+            return 0 if status == "done" else 1
+        if deadline is not None and time.time() >= deadline:
+            if not args.quiet:
+                print_result(record, raw_json=args.json)
+            return 124
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/wait_submission.sh
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/environment/wait_submission.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 /app/wait_submission.py "$@"

--- a/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/tests/evaluate.py
+++ b/adapters/frontier-cs-2.0/src/frontier_cs_2_0/task-template/tests/evaluate.py
@@ -27,6 +27,8 @@ VERIFIER_JUDGE_READY_LOG = Path("/logs/verifier/judge_ready.json")
 EVALUATION_JSON = Path("/logs/verifier/evaluation_result.json")
 BEST_AGENT_PAYLOAD = Path("/logs/agent/best_submission_payload.json")
 BEST_AGENT_META = Path("/logs/agent/best_submission_meta.json")
+BEST_JUDGE_PAYLOAD = Path("/logs/judge/best_submission_payload.json")
+BEST_JUDGE_META = Path("/logs/judge/best_submission_meta.json")
 JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
 JUDGE_TIMEOUT_SECONDS = int(os.environ.get("JUDGE_TIMEOUT_SECONDS", "10800"))
 FINAL_ROLE_TOKEN = "{verifier_token}"
@@ -115,16 +117,18 @@ def copy_judge_artifacts() -> None:
         except OSError as exc:
             print(f"WARN: failed to copy submissions.jsonl: {exc}")
 
-    seen: set[str] = set()
+    by_uuid: dict[str, dict] = {}
     VERIFIER_SUBMISSIONS_LOG.parent.mkdir(parents=True, exist_ok=True)
+    status_rank = {"queued": 0, "running": 1, "cancelled": 2, "error": 3, "done": 4}
+    for record in records:
+        if record.get("submission_role", "agent") != "agent":
+            continue
+        key = str(record.get("submission_uuid") or json.dumps(record, sort_keys=True))
+        previous = by_uuid.get(key)
+        if previous is None or status_rank.get(str(record.get("status")), -1) >= status_rank.get(str(previous.get("status")), -1):
+            by_uuid[key] = record
     with VERIFIER_SUBMISSIONS_LOG.open("w", encoding="utf-8") as dst:
-        for record in records:
-            if record.get("submission_role", "agent") != "agent":
-                continue
-            key = str(record.get("submission_uuid") or json.dumps(record, sort_keys=True))
-            if key in seen:
-                continue
-            seen.add(key)
+        for record in by_uuid.values():
             dst.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     if JUDGE_READY_LOG.exists():
@@ -193,6 +197,41 @@ def wait_for_judge() -> None:
     raise RuntimeError(f"judge service is not ready at {JUDGE_URL}: {last_error}")
 
 
+def get_judge_submissions() -> list[dict]:
+    try:
+        with request.urlopen(f"{JUDGE_URL}/submissions", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return []
+    records = payload.get("submissions", [])
+    return [record for record in records if isinstance(record, dict)]
+
+
+def wait_for_async_submissions() -> None:
+    deadline = time.time() + JUDGE_TIMEOUT_SECONDS
+    printed = False
+    while True:
+        records = get_judge_submissions()
+        pending = [
+            record
+            for record in records
+            if record.get("submission_role", "agent") == "agent"
+            and record.get("status") in {"queued", "running"}
+        ]
+        if not pending:
+            return
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"timed out waiting for {len(pending)} async submission(s) to finish"
+            )
+        if not printed:
+            print(
+                f"Waiting for {len(pending)} async submission(s) before final verification"
+            )
+            printed = True
+        time.sleep(1)
+
+
 def post_json(url: str, payload: dict) -> dict:
     body = json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"}
@@ -235,10 +274,11 @@ def build_judge_payload(solution_path: Path, config: dict) -> dict:
 
 
 def load_best_agent_payload() -> dict | None:
-    if not BEST_AGENT_PAYLOAD.exists():
+    payload_path = BEST_JUDGE_PAYLOAD if BEST_JUDGE_PAYLOAD.exists() else BEST_AGENT_PAYLOAD
+    if not payload_path.exists():
         return None
     try:
-        payload = json.loads(BEST_AGENT_PAYLOAD.read_text(encoding="utf-8"))
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
     except Exception as exc:
         print(f"WARN: failed to read best agent payload: {exc}")
         return None
@@ -251,10 +291,11 @@ def load_best_agent_payload() -> dict | None:
 
 
 def describe_best_agent_payload() -> str:
-    if not BEST_AGENT_META.exists():
+    meta_path = BEST_JUDGE_META if BEST_JUDGE_META.exists() else BEST_AGENT_META
+    if not meta_path.exists():
         return "best iterative artifact"
     try:
-        meta = json.loads(BEST_AGENT_META.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except Exception:
         return "best iterative artifact"
     if not isinstance(meta, dict):
@@ -301,9 +342,6 @@ def write_result(result: dict) -> None:
 
 
 def main() -> None:
-    copy_judge_artifacts()
-    best = best_submission()
-
     def write_best_submission_reward(reason: str) -> bool:
         if best is None:
             return False
@@ -327,7 +365,12 @@ def main() -> None:
         )
         return True
 
+    best: dict | None = None
     try:
+        wait_for_judge()
+        wait_for_async_submissions()
+        copy_judge_artifacts()
+        best = best_submission()
         config = load_submission_config()
         solution_path = load_submission_path(config)
         if not solution_path.exists():

--- a/src/frontier_cs/cli.py
+++ b/src/frontier_cs/cli.py
@@ -1325,7 +1325,12 @@ def _print_harbor_trial_summary(trial_dir: Path) -> None:
 def _harbor_submission_event_key(event: dict) -> tuple[str, str, str, str]:
     submission_uuid = event.get("submission_uuid")
     if submission_uuid:
-        return ("uuid", str(submission_uuid), "", "")
+        return (
+            "uuid",
+            str(submission_uuid),
+            str(event.get("status") or ""),
+            str(event.get("score") or event.get("reward") or ""),
+        )
     return (
         str(event.get("timestamp") or ""),
         str(event.get("status") or ""),
@@ -1358,15 +1363,22 @@ def _submission_log_event(line: str) -> dict | None:
         record = json.loads(line)
     except json.JSONDecodeError:
         return None
-    if record.get("status") != "done":
+    status = record.get("status")
+    if status not in {"queued", "running", "done", "error", "cancelled"}:
         return None
+    raw_score = record.get("score_raw", record.get("score"))
+    reward = record.get("score")
+    if "score_raw" not in record:
+        parsed_raw_score = _parse_float(raw_score)
+        reward = parsed_raw_score / 100.0 if parsed_raw_score is not None else None
     return {
         "timestamp": record.get("ts"),
-        "status": record.get("status"),
-        "reward": record.get("score"),
-        "score": record.get("score_raw", record.get("score")),
+        "status": status,
+        "reward": reward,
+        "score": raw_score,
         "code_chars": record.get("code_chars"),
         "submission_uuid": record.get("submission_uuid"),
+        "message": record.get("message") or record.get("error"),
     }
 
 
@@ -1380,8 +1392,13 @@ def _poll_harbor_submission_events(
         return []
 
     events = []
-    submissions_log = trial_dir / "agent" / "submissions.jsonl"
-    if submissions_log.exists():
+    submission_logs = [
+        trial_dir / "agent" / "submissions.jsonl",
+        trial_dir / "judge" / "submissions.jsonl",
+    ]
+    for submissions_log in submission_logs:
+        if not submissions_log.exists():
+            continue
         for line in _read_new_text(submissions_log, file_offsets).splitlines():
             event = _submission_log_event(line)
             if event is None:
@@ -1438,6 +1455,17 @@ def _print_harbor_submission_event(
     best = max(scores) if scores else score
     code_chars = event.get("code_chars")
     suffix = f" code_chars={code_chars}" if code_chars is not None else ""
+    if event.get("status") != "done":
+        message = event.get("message")
+        detail = f" detail={message}" if message else ""
+        print(
+            "[frontier harbor] "
+            f"submission #{index} {timestamp} "
+            f"status={event.get('status')}{suffix}{detail}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
     print(
         "[frontier harbor] "
         f"submission #{index} {timestamp} "
@@ -1498,6 +1526,7 @@ def _run_harbor_command_live(
     seen_events: set[tuple[str, str, str, str]] = set()
     scores: list[float] = []
     submission_count = 0
+    submission_indices: dict[str, int] = {}
     stdout_closed = False
 
     while True:
@@ -1536,13 +1565,21 @@ def _run_harbor_command_live(
             file_offsets=file_offsets,
             seen=seen_events,
         ):
-            submission_count += 1
+            submission_uuid = str(event.get("submission_uuid") or "")
+            if submission_uuid:
+                if submission_uuid not in submission_indices:
+                    submission_count += 1
+                    submission_indices[submission_uuid] = submission_count
+                event_index = submission_indices[submission_uuid]
+            else:
+                submission_count += 1
+                event_index = submission_count
             score = _parse_float(event.get("score"))
             previous_score = scores[-1] if scores else 0.0
             if score is not None:
                 scores.append(score)
             _print_harbor_submission_event(
-                submission_count, event, scores, previous_score
+                event_index, event, scores, previous_score
             )
 
         if stdout_closed and process.poll() is not None:


### PR DESCRIPTION
## Summary
- add async submission queues for Frontier-CS 2.0 Harbor tasks
- add task-local submit/list/wait/cancel helpers and shared AGENT.md guidance
- stream queued/running/done submission progress in the Frontier-CS Harbor wrapper
- wait for queued/running async submissions before final verification and preserve best iterative fallback
- make async queue size task-configurable with a default of 3

## Tests
- `python3 -m py_compile ...` for updated 2.0 template, verifier, adapter, and CLI files
- generated representative 2.0 Harbor tasks: `erdos_demo`, `vector_db_ann`, `bboplace_direct_ispd2005`
- `uv run frontier eval algorithmic 0 algorithmic/problems/0/examples/reference.cpp --backend docker`
- `uv run frontier harbor trial algorithmic 0 -a codex -m gpt-5.5 --agent-timeout 300 --verifier-timeout 300 --force-build --json`
- `uv run frontier harbor trial 2.0 bboplace_direct_ispd2005 -a codex -m gpt-5.5 --agent-timeout 600 --verifier-timeout 600 --force-build --json`