### PR TITLE
[Habor Adapter] Fix algorithmic iterative submission artifacts

### DIFF
--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py
@@ -32,13 +32,12 @@ def _submission_sort_key(path: Path) -> tuple[int, str]:
 
 def judge_submission_records() -> list[dict]:
     """Rebuild the iterative submission log from judge-owned artifacts."""
-    problem_dir = JUDGE_SUBMISSIONS_DIR / str(PROBLEM_ID)
-    if not problem_dir.exists():
+    if not JUDGE_SUBMISSIONS_DIR.exists():
         return []
 
     records: list[dict] = []
     for result_path in sorted(
-        problem_dir.glob("*/result.json"), key=_submission_sort_key
+        JUDGE_SUBMISSIONS_DIR.glob("*/*/result.json"), key=_submission_sort_key
     ):
         try:
             result = json.loads(result_path.read_text())
@@ -53,6 +52,10 @@ def judge_submission_records() -> list[dict]:
             except (OSError, json.JSONDecodeError):
                 meta = {}
 
+        record_pid = str(meta.get("pid") or result_path.parent.parent.name)
+        if record_pid != str(PROBLEM_ID):
+            continue
+
         score_raw = result.get("score") or 0.0
         try:
             reward = float(score_raw) / 100.0
@@ -64,7 +67,7 @@ def judge_submission_records() -> list[dict]:
                 "ts": meta.get("ts"),
                 "status": result.get("status", "unknown"),
                 "sid": meta.get("sid") or result_path.parent.name,
-                "problem_id": meta.get("pid") or PROBLEM_ID,
+                "problem_id": record_pid,
                 "score": reward,
                 "score_raw": score_raw,
                 "score_unbounded": result.get("scoreUnbounded"),


### PR DESCRIPTION
## Summary
Fix Frontier-CS algorithmic Harbor verifier reconstruction of iterative submission artifacts.

The judge stores submissions under bucket directories such as `submissions/0/1`, where `0` is a submission bucket prefix rather than the problem id. The verifier previously read only `submissions/<PROBLEM_ID>/*/result.json`, which worked accidentally for problem 0 but dropped iterative submissions for nonzero problem ids. This PR scans all submission buckets and filters by `meta.json`'s `pid` instead.

## Type of Change
- [ ] New research problem
- [ ] New algorithmic problem
- [ ] New Frontier-CS 2.0 problem
- [x] Bug fix
- [ ] Documentation update
- [ ] Other:

## Testing
- `uv run python -m py_compile adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py`
- local artifact fixture: created `submissions/0/1/meta.json` with `pid=6` and confirmed `judge_submission_records()` returns that record while filtering another `pid=7` record

## Checklist
- [x] Code follows the project structure and conventions
- [x] Self-review completed
- [x] Documentation updated (if applicable)

## CI Validation (for new problems)
> Not applicable; this PR does not add a new problem.