### PR TITLE
Fix: hide per-case judge messages from result payloads

### DIFF
--- a/adapters/frontier-cs-algorithm/README.md
+++ b/adapters/frontier-cs-algorithm/README.md
@@ -47,9 +47,9 @@ the average of per-case scores normalized to `[0, 1]` and written to
   are shallow-cloned into a temp directory and cleaned up on exit.
 - **172 tasks generated**: one per problem; type detection (`default` vs
   `interactive`) drives prompt and verifier choices.
-- **HTTP judge sidecar**: every task's `docker-compose.yaml` brings up the
-  upstream Frontier-CS judge as a `judge` service; the verifier in `main`
-  POSTs `/app/solution.cpp` and polls for the score.
+- **HTTP judge sidecar**: every task's `docker-compose.yaml` exposes a
+  `judge` service that accepts C++ submissions and returns sanitized aggregate
+  scores to the agent and verifier.
 - **Interactive graded submissions**: agents can run `bash /app/submit.sh`
   during a trial to grade the current solution with the same judge used by the
   final verifier.
@@ -59,7 +59,7 @@ the average of per-case scores normalized to `[0, 1]` and written to
   solution but before leaving a better final file.
 - **Process reward artifacts**: `/logs/agent/submissions.jsonl` is used for
   live progress display; final scoring rebuilds `/logs/verifier/submissions.jsonl`
-  from judge-owned artifacts under `/logs/artifacts/judge/submissions`.
+  from sanitized judge-side submission records.
 - **Per-task verifier timeout**: scaled as
   `max(120, n_cases * time_limit_seconds * 5 + 60)` so harder problems
   with many cases do not time out before the judge finishes.
@@ -72,9 +72,10 @@ the average of per-case scores normalized to `[0, 1]` and written to
 - **Reusable local images**: optional `--build-local-images` and
   `--use-published-judge` flags emit tasks that reuse a prebuilt main and/or
   judge image, which is much faster for repeated local runs.
-- **Cleaner default artifacts**: judge submissions stay under the Harbor
-  job's `artifacts/`, while judge `data` lives in a Docker-managed volume by
-  default; `--preserve-judge-artifacts` opts into bind-mounting it.
+- **Cleaner default artifacts**: agent- and verifier-visible submission logs
+  contain sanitized scores and metadata. Raw judge-engine submissions and data
+  live in Docker-managed volumes by default; `--preserve-judge-artifacts` opts
+  into bind-mounting them for debugging.
 
 ## Generated Task Structure
 
@@ -86,6 +87,7 @@ frontier-cs-algorithm/
 │   ├── environment/              # Docker bring-up
 │   │   ├── Dockerfile            # main image (g++, python, agent CLIs)
 │   │   ├── docker-compose.yaml   # main + judge services
+│   │   ├── judge_proxy.py        # sanitized judge-facing HTTP endpoint
 │   │   ├── submit.sh             # agent-facing iterative submit entry point
 │   │   ├── submit.py             # submit helper + submissions.jsonl logging
 │   │   ├── AGENT.md              # parity-mode agent rules
@@ -96,7 +98,7 @@ frontier-cs-algorithm/
 │   │   └── reference.cpp         # only when upstream ships one
 │   └── tests/
 │       ├── test.sh               # Harbor verifier entry point
-│       └── evaluate.py           # POSTs to judge, polls, writes reward
+│       └── evaluate.py           # submits to judge and writes reward artifacts
 ```
 
 The adapter package itself follows the standard `src/` layout produced by
@@ -202,9 +204,9 @@ Available flags:
 - `--use-published-judge` — Pull the published judge image
   (`yanagiorigami/frontier-cs-harbor-judge:latest`) and retag it locally so
   generated tasks can keep referencing the stable local tag.
-- `--preserve-judge-artifacts` — Bind-mount the judge `data` directory into
-  the Harbor job artifacts (debugging only; default keeps it in a Docker
-  volume).
+- `--preserve-judge-artifacts` — Bind-mount raw judge-engine submissions and
+  `data` into the Harbor job artifacts (debugging only; default keeps them in
+  Docker volumes).
 
 Each generated task lives at `datasets/frontier-cs-algorithm/frontier-cs-algorithm-{id}/`
 (top-level `datasets/frontier-cs-algorithm/` matches the adapter folder; each
@@ -365,10 +367,13 @@ images.
 agent's transcript; for token-limit truncations the agent simply ran out of
 budget before emitting a final solution.
 
-**Judge returns `Unknown error`** — look at the raw judge artifacts under
-`artifacts/judge/submissions/<id>/{source.code,result.json}`. Use
-`--preserve-judge-artifacts` when generating tasks if you also need the
-judge `data` directory for debugging.
+**Judge returns `Unknown error`** — first inspect
+`verifier/judge_result.json`, `verifier/submissions.jsonl`, and the sanitized
+judge-side log under `artifacts/judge/proxy/submissions.jsonl`. If you need raw
+judge-engine internals for debugging, regenerate the task with
+`--preserve-judge-artifacts` and inspect
+`artifacts/judge/submissions/<id>/{source.code,result.json}` plus
+`artifacts/judge/data`.
 
 **Docker path issues** — confirm `FRONTIER_CS_ALGORITHMIC_PATH` points at
 the `algorithmic` directory of a Frontier-CS checkout, not the repo root.

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/adapter.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/adapter.py
@@ -245,8 +245,14 @@ class FrontierCSAdapter:
         problem_files = self._copy_problem_files(task_paths, problem)
         self._write_agent_md(task_paths, problem)
 
+        verifier_timeout = self._verifier_timeout(problem)
+        max_poll_time = int(verifier_timeout - 30)
         (task_paths.environment_dir / "docker-compose.yaml").write_text(
-            self._render_environment_compose(problem.problem_id, problem_files)
+            self._render_environment_compose(
+                problem.problem_id,
+                problem_files,
+                max_poll_time=max_poll_time,
+            )
         )
 
     def _copy_problem_files(
@@ -275,7 +281,11 @@ class FrontierCSAdapter:
         (task_paths.environment_dir / "AGENT.md").write_text(content)
 
     def _render_environment_compose(
-        self, problem_id: int, problem_files: list[str]
+        self,
+        problem_id: int,
+        problem_files: list[str],
+        *,
+        max_poll_time: int,
     ) -> str:
         if self.judge_docker_image:
             judge_source = f'    image: "{self.judge_docker_image}"'
@@ -285,13 +295,16 @@ class FrontierCSAdapter:
         # Mount only the single problem dir (judge resolves problemsRoot/{id}).
         judge_volume_lines = [
             f"      - ${{FRONTIER_CS_ALGORITHMIC_PATH}}/problems/{problem_id}:/app/problems/{problem_id}:ro",
-            "      - ${HOST_ARTIFACTS_PATH}/judge/submissions:/app/submissions",
         ]
         if self.preserve_judge_artifacts:
+            judge_volume_lines.append(
+                "      - ${HOST_ARTIFACTS_PATH}/judge/submissions:/app/submissions"
+            )
             judge_volume_lines.append(
                 "      - ${HOST_ARTIFACTS_PATH}/judge/data:/app/data"
             )
         else:
+            judge_volume_lines.append("      - /app/submissions")
             judge_volume_lines.append("      - /app/data")
         judge_volumes = "\n".join(judge_volume_lines)
 
@@ -316,6 +329,7 @@ class FrontierCSAdapter:
             judge_source=judge_source,
             judge_volumes=judge_volumes,
             problem_id=problem_id,
+            max_poll_time=max_poll_time,
         )
 
     def _write_tests(self, task_paths: TaskPaths) -> None:
@@ -350,9 +364,7 @@ class FrontierCSAdapter:
         template_text = config_template.read_text().replace(
             "{problem_id}", str(problem.problem_id)
         )
-        verifier_timeout = max(
-            120.0, problem.n_cases * problem.time_limit_seconds * 5 + 60
-        )
+        verifier_timeout = self._verifier_timeout(problem)
         max_poll_time = int(verifier_timeout - 30)
 
         metadata = {
@@ -385,7 +397,7 @@ class FrontierCSAdapter:
             # evaluate.py can write the reward file before the container is killed.
             config.verifier.env = {
                 "PROBLEM_ID": str(problem.problem_id),
-                "JUDGE_URL": "http://judge:8081",
+                "JUDGE_URL": "http://judge:8082",
                 "MAX_POLL_TIME": str(max_poll_time),
             }
 
@@ -404,6 +416,10 @@ class FrontierCSAdapter:
                 docker_image=self.docker_image,
             )
         task_paths.config_path.write_text(toml_text)
+
+    @staticmethod
+    def _verifier_timeout(problem: FrontierCSProblem) -> float:
+        return max(120.0, problem.n_cases * problem.time_limit_seconds * 5 + 60)
 
 
 def _collapse_task_authors_inline(toml_text: str) -> str:
@@ -498,7 +514,7 @@ def _render_task_toml_without_harbor(
     verifier_env = (
         "\n[verifier.env]\n"
         f'PROBLEM_ID = "{problem.problem_id}"\n'
-        'JUDGE_URL = "http://judge:8081"\n'
+        'JUDGE_URL = "http://judge:8082"\n'
         f'MAX_POLL_TIME = "{max_poll_time}"\n'
     )
     text = text.replace("\n[agent]\n", verifier_env + "\n[agent]\n", 1)

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/agent_constants.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/agent_constants.py
@@ -107,16 +107,17 @@ Do NOT skip self-testing. This is standard competitive programming practice.
 
 ## Iterative submission via the graded judge
 
-You have direct access to the same judge that produces the final score. Use it
-as a feedback signal; there is no penalty for low-scoring submissions.
+You have access to a graded submission endpoint backed by the same judge that
+produces the final score. Use its sanitized score feedback as a signal; there is
+no penalty for low-scoring submissions.
 
 ```bash
 bash /app/submit.sh           # grades /app/solution.cpp
 bash /app/submit.sh path.cpp  # grades any file you point at
 ```
 
-Each call prints the status, normalized score, raw score, judge feedback, and
-case pass count when available. Every call is recorded in
+Each call prints the status, normalized score, raw score, sanitized feedback,
+and aggregate metrics when available. Every call is recorded in
 `/logs/agent/submissions.jsonl` for analysis, including failed calls.
 """
 

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/docker-compose.yaml
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/docker-compose.yaml
@@ -2,15 +2,49 @@ services:
   main:
     depends_on:
       judge:
-        condition: service_started
+        condition: service_healthy
     environment:
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: "128000"
       PROBLEM_ID: "{problem_id}"
-      JUDGE_URL: "http://judge:8081"
+      JUDGE_URL: "http://judge:8082"
     volumes:
 {main_volumes}
+    networks:
+      - agent_net
 
   judge:
+    image: "python:3.12-slim"
+    depends_on:
+      judge-engine:
+        condition: service_started
+    command: ["python3", "/judge/judge_proxy.py"]
+    expose:
+      - "8082"
+    environment:
+      PORT: "8082"
+      PROBLEM_ID: "{problem_id}"
+      JUDGE_ENGINE_URL: "http://judge-engine:8081"
+      MAX_POLL_TIME: "{max_poll_time}"
+    volumes:
+      - ./judge_proxy.py:/judge/judge_proxy.py:ro
+      - ${{HOST_ARTIFACTS_PATH}}/judge/proxy:/logs/judge
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8082/health', timeout=2).read()",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 360
+      start_period: 5s
+    networks:
+      - agent_net
+      - judge_net
+
+  judge-engine:
 {judge_source}
     privileged: true
     shm_size: "4g"
@@ -26,3 +60,10 @@ services:
       SAVE_OUTPUTS: "false"
     volumes:
 {judge_volumes}
+    networks:
+      - judge_net
+
+networks:
+  agent_net:
+  judge_net:
+    internal: true

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/judge_proxy.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/judge_proxy.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Black-box Harbor judge proxy for Frontier-CS algorithmic tasks.
+
+The upstream go-judge service keeps detailed checker/interactor output for
+score aggregation and artifacts. This proxy is the only judge endpoint exposed
+to the agent container; it submits code to the upstream engine and returns a
+small, sanitized score result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import traceback
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib import error, parse, request
+
+ENGINE_URL = os.environ.get("JUDGE_ENGINE_URL", "http://judge-engine:8081").rstrip("/")
+PORT = int(os.environ.get("PORT", "8082"))
+PROBLEM_ID = os.environ.get("PROBLEM_ID", "")
+POLL_INTERVAL_SECONDS = float(os.environ.get("POLL_INTERVAL_SECONDS", "2"))
+MAX_POLL_TIME_SECONDS = float(os.environ.get("MAX_POLL_TIME", "600"))
+MAX_SUBMISSION_BYTES = int(os.environ.get("MAX_SUBMISSION_BYTES", "10000000"))
+SUBMISSIONS_LOG = Path("/logs/judge/submissions.jsonl")
+
+
+def now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def log_submission(record: dict[str, Any]) -> None:
+    SUBMISSIONS_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with SUBMISSIONS_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"ts": now_iso(), **record}, ensure_ascii=False) + "\n")
+
+
+def read_submissions() -> list[dict[str, Any]]:
+    if not SUBMISSIONS_LOG.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in SUBMISSIONS_LOG.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def get_json(path: str, timeout: float = 10) -> dict[str, Any]:
+    with request.urlopen(f"{ENGINE_URL}{path}", timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected JSON payload from {path}")
+    return payload
+
+
+def post_form(path: str, fields: dict[str, str], timeout: float = 30) -> dict[str, Any]:
+    body = parse.urlencode(fields).encode("utf-8")
+    req = request.Request(
+        f"{ENGINE_URL}{path}",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected JSON payload from {path}")
+    return payload
+
+
+def wait_for_engine() -> dict[str, Any]:
+    return get_json("/problems", timeout=5)
+
+
+def submit_to_engine(problem_id: str, code: str) -> int:
+    payload = post_form(
+        "/submit",
+        {"pid": problem_id, "lang": "cpp", "code": code},
+        timeout=30,
+    )
+    sid = payload.get("sid")
+    if not isinstance(sid, int):
+        raise RuntimeError(f"judge engine did not return a submission id: {payload}")
+    return sid
+
+
+def poll_engine_result(sid: int) -> dict[str, Any]:
+    start = time.time()
+    while time.time() - start < MAX_POLL_TIME_SECONDS:
+        try:
+            result = get_json(f"/result/{sid}", timeout=10)
+        except error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+            time.sleep(POLL_INTERVAL_SECONDS)
+            continue
+        if result.get("status") in ("done", "error"):
+            return result
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise TimeoutError(f"evaluation timed out after {MAX_POLL_TIME_SECONDS}s")
+
+
+def sanitize_result(raw: dict[str, Any], sid: int) -> dict[str, Any]:
+    score = float(raw.get("score") or 0.0)
+    score_unbounded = raw.get("scoreUnbounded", score)
+    try:
+        score_unbounded = float(score_unbounded)
+    except (TypeError, ValueError):
+        score_unbounded = score
+
+    cases = raw.get("cases")
+    total_cases = len(cases) if isinstance(cases, list) else None
+    perfect_cases = None
+    if isinstance(cases, list):
+        perfect_cases = 0
+        for case in cases:
+            if isinstance(case, dict) and float(case.get("scoreRatio") or 0.0) == 1.0:
+                perfect_cases += 1
+
+    metrics: dict[str, Any] = {"sid": sid}
+    if total_cases is not None:
+        metrics["total_cases"] = total_cases
+    if perfect_cases is not None:
+        metrics["perfect_cases"] = perfect_cases
+
+    if raw.get("status") == "error":
+        return {
+            "status": "error",
+            "score": 0.0,
+            "score_unbounded": 0.0,
+            "message": "judge engine error",
+            "metrics": metrics,
+        }
+
+    passed = bool(raw.get("passed", False))
+    result = str(raw.get("result") or ("Correct Answer" if passed else "Wrong Answer"))
+    return {
+        "status": "done",
+        "score": score,
+        "score_unbounded": score_unbounded,
+        "passed": passed,
+        "message": result,
+        "metrics": metrics,
+    }
+
+
+def evaluate_code(payload: dict[str, Any]) -> dict[str, Any]:
+    code = payload.get("code")
+    if not isinstance(code, str) or not code.strip():
+        raise ValueError("request must include non-empty string field 'code'")
+    problem_id = str(payload.get("problem_id") or PROBLEM_ID)
+    if not problem_id:
+        raise ValueError("problem_id is required")
+    sid = submit_to_engine(problem_id, code)
+    raw_result = poll_engine_result(sid)
+    return sanitize_result(raw_result, sid)
+
+
+class JudgeProxyHandler(BaseHTTPRequestHandler):
+    server_version = "FrontierCSAlgorithmJudgeProxy/1.0"
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            try:
+                wait_for_engine()
+                self._write_json(200, {"status": "ok", "ready": True})
+            except Exception as exc:
+                self._write_json(
+                    503,
+                    {"status": "error", "ready": False, "error": str(exc)},
+                )
+            return
+        if self.path == "/submissions":
+            self._write_json(200, {"status": "ok", "submissions": read_submissions()})
+            return
+        self._write_json(404, {"status": "error", "error": "not found"})
+
+    def do_POST(self) -> None:
+        if self.path != "/evaluate":
+            self._write_json(404, {"status": "error", "error": "not found"})
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._write_json(400, {"status": "error", "error": "invalid content length"})
+            return
+        if content_length <= 0:
+            self._write_json(400, {"status": "error", "error": "empty request body"})
+            return
+        if content_length > MAX_SUBMISSION_BYTES:
+            self._write_json(413, {"status": "error", "error": "submission too large"})
+            return
+
+        submission_uuid = ""
+        submission_role = "agent"
+        try:
+            payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("request body must be a JSON object")
+            submission_uuid = str(payload.get("submission_uuid") or "")
+            submission_role = str(payload.get("submission_role") or "agent")
+            result = evaluate_code(payload)
+            log_submission(
+                {
+                    "submission_uuid": submission_uuid,
+                    "submission_role": submission_role,
+                    "problem_id": str(payload.get("problem_id") or PROBLEM_ID),
+                    **result,
+                }
+            )
+            self._write_json(200, result)
+        except Exception as exc:
+            detail = traceback.format_exc()
+            result = {
+                "status": "error",
+                "score": 0.0,
+                "score_unbounded": 0.0,
+                "message": str(exc),
+                "metrics": {},
+            }
+            log_submission(
+                {
+                    "submission_uuid": submission_uuid,
+                    "submission_role": submission_role,
+                    "problem_id": PROBLEM_ID,
+                    **result,
+                    "detail": detail,
+                }
+            )
+            self._write_json(200, result)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        print(
+            f"[{now_iso()}] {self.address_string()} {format % args}",
+            flush=True,
+        )
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), JudgeProxyHandler)
+    print(
+        f"[frontier algorithm judge proxy] listening on {PORT}, engine={ENGINE_URL}",
+        flush=True,
+    )
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/submit.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/submit.py
@@ -6,16 +6,14 @@ graded judge. Each call:
 
 1. Writes a `started` record to /logs/agent/submissions.jsonl (so we know the
    call existed even if everything downstream fails).
-2. POSTs /app/solution.cpp (or the first arg) to the judge sidecar.
-3. Polls until the judge returns done/error.
-4. Writes a `done`/`error` record with the same submission_uuid, then prints
+2. POSTs /app/solution.cpp (or the first arg) to the black-box judge sidecar.
+3. Writes a `done`/`error` record with the same submission_uuid, then prints
    a concise score + feedback summary so the agent sees it on stdout.
 
 Exit code semantics:
 - 0: judge returned a result (score may be low — that's still success).
 - 2: solution file missing / empty.
-- 3: judge submit request failed.
-- 4: judge polling timed out.
+- 3: judge request failed.
 - 5: unexpected runtime error.
 
 The post-hoc analysis joins submissions.jsonl with the agent's trajectory
@@ -33,11 +31,10 @@ from pathlib import Path
 
 import requests
 
-JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8081")
+JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
 PROBLEM_ID = os.environ.get("PROBLEM_ID", "")
 SUBMISSIONS_LOG = Path("/logs/agent/submissions.jsonl")
-POLL_INTERVAL = 2.0
-MAX_POLL_TIME = float(os.environ.get("SUBMIT_MAX_POLL_TIME", "600"))
+JUDGE_TIMEOUT_SECONDS = float(os.environ.get("SUBMIT_MAX_POLL_TIME", "600"))
 
 
 def now_iso() -> str:
@@ -52,6 +49,44 @@ def log_record(record: dict) -> None:
     SUBMISSIONS_LOG.parent.mkdir(parents=True, exist_ok=True)
     with SUBMISSIONS_LOG.open("a") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def wait_for_judge() -> None:
+    deadline = time.time() + JUDGE_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    printed_waiting = False
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"{JUDGE_URL}/health", timeout=5)
+            if response.status_code == 200:
+                return
+            last_error = RuntimeError(response.text)
+        except Exception as exc:
+            last_error = exc
+        if not printed_waiting:
+            print("[submit] waiting for judge service", flush=True)
+            printed_waiting = True
+        time.sleep(1)
+    raise RuntimeError(f"judge service is not ready at {JUDGE_URL}: {last_error}")
+
+
+def evaluate_with_judge(submission_uuid: str, code: str) -> dict:
+    wait_for_judge()
+    response = requests.post(
+        f"{JUDGE_URL}/evaluate",
+        json={
+            "submission_uuid": submission_uuid,
+            "submission_role": "agent",
+            "problem_id": PROBLEM_ID,
+            "code": code,
+        },
+        timeout=JUDGE_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    result = response.json()
+    if result.get("status") not in ("done", "error"):
+        raise RuntimeError(str(result.get("message") or result))
+    return result
 
 
 def main() -> int:
@@ -100,16 +135,11 @@ def main() -> int:
         return 2
 
     try:
-        r = requests.post(
-            f"{JUDGE_URL}/submit",
-            files={"code": ("solution.cpp", code)},
-            data={"pid": PROBLEM_ID, "lang": "cpp"},
-            timeout=30,
-        )
-        r.raise_for_status()
-        sid = r.json()["sid"]
+        start = time.time()
+        result = evaluate_with_judge(sub_uuid, code)
+        elapsed_seconds = time.time() - start
     except Exception as exc:
-        msg = f"Submit request failed: {exc}"
+        msg = f"Judge request failed: {exc}"
         print(f"[submit] ERROR: {msg}", file=sys.stderr)
         log_record(
             {
@@ -121,74 +151,48 @@ def main() -> int:
         )
         return 3
 
-    print(f"[submit] uuid={sub_uuid} sid={sid} pid={PROBLEM_ID} evaluating...")
-
-    start = time.time()
-    result: dict | None = None
-    while time.time() - start < MAX_POLL_TIME:
-        try:
-            r = requests.get(f"{JUDGE_URL}/result/{sid}", timeout=10)
-            if r.status_code == 200:
-                data = r.json()
-                if data.get("status") in ("done", "error"):
-                    result = data
-                    break
-        except Exception:
-            pass
-        time.sleep(POLL_INTERVAL)
-
-    if result is None:
-        msg = f"Polling timed out after {MAX_POLL_TIME}s"
-        print(f"[submit] ERROR: {msg}", file=sys.stderr)
-        log_record(
-            {
-                "submission_uuid": sub_uuid,
-                "ts": now_iso(),
-                "status": "error",
-                "sid": sid,
-                "error": msg,
-            }
-        )
-        return 4
-
     score_raw = result.get("score") or 0.0
     try:
         score = float(score_raw) / 100.0
     except (TypeError, ValueError):
         score = 0.0
     status = result.get("status", "unknown")
-    detail = result.get("message") or result.get("detail") or ""
+    detail = result.get("message") or ""
+    score_unbounded = result.get("score_unbounded", score_raw)
+    metrics = result.get("metrics") or {}
+    if not isinstance(metrics, dict):
+        metrics = {}
 
     log_record(
         {
             "submission_uuid": sub_uuid,
             "ts": now_iso(),
             "status": status,
-            "sid": sid,
             "score": score,
             "score_raw": score_raw,
+            "score_unbounded": score_unbounded,
             "detail": detail,
-            "raw_result": result,
+            "elapsed_seconds": elapsed_seconds,
             "code_chars": code_chars,
+            "metrics": metrics,
         }
     )
 
-    print(f"[submit] uuid={sub_uuid} sid={sid}")
+    print(f"[submit] uuid={sub_uuid}")
     print(
         f"[submit] status={status} score={score:.4f} "
         f"(raw={score_raw}/100) code_chars={code_chars}"
     )
+    if score_unbounded != score_raw:
+        print(f"[submit] unbounded={score_unbounded}")
     if detail:
         snippet = detail if len(detail) <= 500 else detail[:500] + "..."
         print(f"[submit] detail: {snippet}")
-    cases = result.get("cases") or result.get("results") or []
-    if isinstance(cases, list) and cases:
-        passed = sum(
-            1
-            for c in cases
-            if isinstance(c, dict) and (c.get("score") or 0) > 0
+    if metrics:
+        metric_text = " ".join(
+            f"{key}={value}" for key, value in sorted(metrics.items())
         )
-        print(f"[submit] cases: {passed}/{len(cases)} passed")
+        print(f"[submit] metrics: {metric_text}")
 
     return 0
 

--- a/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py
+++ b/adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py
@@ -1,84 +1,65 @@
 #!/usr/bin/env python3
 """
 Harbor verifier for Frontier-CS algorithmic problems.
-Submits the agent's C++ code to the go-judge HTTP API and retrieves the score.
+Submits the agent's C++ code to the black-box judge proxy and retrieves the score.
 """
 
 import json
 import os
 import time
+import uuid
 from pathlib import Path
 
 import requests
 
-JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8081")
+JUDGE_URL = os.environ.get("JUDGE_URL", "http://judge:8082").rstrip("/")
 PROBLEM_ID = os.environ.get("PROBLEM_ID", "0")
 SOLUTION_PATH = Path("/app/solution.cpp")
 REWARD_TXT = Path("/logs/verifier/reward.txt")
 REWARD_JSON = Path("/logs/verifier/reward.json")
-JUDGE_SUBMISSIONS_DIR = Path("/logs/artifacts/judge/submissions")
 VERIFIER_SUBMISSIONS_LOG = Path("/logs/verifier/submissions.jsonl")
 JUDGE_RESULT_JSON = Path("/logs/verifier/judge_result.json")
-POLL_INTERVAL = 2  # seconds
 MAX_POLL_TIME = int(os.environ.get("MAX_POLL_TIME", "600"))  # seconds
 
 
-def _submission_sort_key(path: Path) -> tuple[int, str]:
-    try:
-        return (int(path.parent.name), path.parent.name)
-    except ValueError:
-        return (10**18, path.parent.name)
-
-
 def judge_submission_records() -> list[dict]:
-    """Rebuild the iterative submission log from judge-owned artifacts."""
-    if not JUDGE_SUBMISSIONS_DIR.exists():
+    """Fetch sanitized iterative submission records from the judge proxy."""
+    try:
+        response = requests.get(f"{JUDGE_URL}/submissions", timeout=10)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        print(f"WARN: failed to fetch judge submissions: {exc}")
         return []
 
-    records: list[dict] = []
-    for result_path in sorted(
-        JUDGE_SUBMISSIONS_DIR.glob("*/*/result.json"), key=_submission_sort_key
-    ):
-        try:
-            result = json.loads(result_path.read_text())
-        except (OSError, json.JSONDecodeError):
+    records = payload.get("submissions", [])
+    if not isinstance(records, list):
+        return []
+
+    normalized: list[dict] = []
+    for record in records:
+        if not isinstance(record, dict):
             continue
-
-        meta: dict = {}
-        meta_path = result_path.parent / "meta.json"
-        if meta_path.exists():
-            try:
-                meta = json.loads(meta_path.read_text())
-            except (OSError, json.JSONDecodeError):
-                meta = {}
-
-        record_pid = str(meta.get("pid") or result_path.parent.parent.name)
-        if record_pid != str(PROBLEM_ID):
-            continue
-
-        score_raw = result.get("score") or 0.0
+        score_raw = record.get("score") or 0.0
         try:
             reward = float(score_raw) / 100.0
         except (TypeError, ValueError):
             reward = 0.0
-
-        records.append(
+        normalized.append(
             {
-                "ts": meta.get("ts"),
-                "status": result.get("status", "unknown"),
-                "sid": meta.get("sid") or result_path.parent.name,
-                "problem_id": record_pid,
+                "ts": record.get("ts"),
+                "status": record.get("status", "unknown"),
+                "submission_role": record.get("submission_role", "agent"),
+                "submission_uuid": record.get("submission_uuid"),
+                "problem_id": record.get("problem_id") or PROBLEM_ID,
                 "score": reward,
                 "score_raw": score_raw,
-                "score_unbounded": result.get("scoreUnbounded"),
-                "detail": result.get("message")
-                or result.get("detail")
-                or result.get("result")
-                or "",
-                "raw_result": result,
+                "score_unbounded": record.get("score_unbounded", score_raw),
+                "detail": record.get("message") or "",
+                "metrics": record.get("metrics") or {},
             }
         )
-    return records
+    return normalized
 
 
 def write_submissions_log(records: list[dict]) -> None:
@@ -95,6 +76,8 @@ def best_submission(records: list[dict]) -> dict | None:
             reward = float(record.get("score", 0.0))
         except (TypeError, ValueError):
             reward = 0.0
+        if record.get("submission_role", "agent") != "agent":
+            continue
         if record.get("status") != "done":
             continue
         if best is None or reward > float(best.get("score", 0.0)):
@@ -124,6 +107,37 @@ def write_reward(
             sidecar[key] = value
     REWARD_JSON.write_text(json.dumps(numeric_rewards, indent=2))
     JUDGE_RESULT_JSON.write_text(json.dumps(sidecar, indent=2))
+
+
+def wait_for_judge() -> bool:
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"{JUDGE_URL}/health", timeout=5)
+            if response.status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(2)
+    return False
+
+
+def evaluate_with_judge(code: str) -> dict:
+    response = requests.post(
+        f"{JUDGE_URL}/evaluate",
+        json={
+            "submission_uuid": str(uuid.uuid4()),
+            "submission_role": "final",
+            "problem_id": PROBLEM_ID,
+            "code": code,
+        },
+        timeout=MAX_POLL_TIME,
+    )
+    response.raise_for_status()
+    result = response.json()
+    if result.get("status") not in ("done", "error"):
+        raise RuntimeError(str(result.get("message") or result))
+    return result
 
 
 def main():
@@ -170,74 +184,32 @@ def main():
 
     # 2. Wait for judge availability (may take time to start)
     print("Waiting for judge...")
-    judge_ready = False
-    for attempt in range(30):
-        try:
-            r = requests.get(f"{JUDGE_URL}/problems", timeout=5)
-            if r.status_code == 200:
-                judge_ready = True
-                break
-        except Exception:
-            pass
-        time.sleep(2)
-
-    if not judge_ready:
+    if not wait_for_judge():
         print(f"ERROR: Judge not available at {JUDGE_URL} after 60s")
-        print("Check sibling service 'judge' and FRONTIER_CS_ALGORITHMIC_PATH")
         write_reward(0.0, "Judge not available")
         return
 
     print("Judge is ready.")
 
-    # 3. Submit
+    # 3. Evaluate
     print("Submitting...")
     try:
-        r = requests.post(
-            f"{JUDGE_URL}/submit",
-            files={"code": ("solution.cpp", code)},
-            data={"pid": PROBLEM_ID, "lang": "cpp"},
-            timeout=30,
-        )
-        r.raise_for_status()
-        sid = r.json()["sid"]
-        print(f"Submission ID: {sid}")
+        result = evaluate_with_judge(code)
     except Exception as e:
-        print(f"ERROR: Submit failed: {e}")
-        write_reward(0.0, f"Submit failed: {e}")
-        return
-
-    # 4. Poll for result
-    print("Evaluating", end="", flush=True)
-    start = time.time()
-    result = None
-
-    while time.time() - start < MAX_POLL_TIME:
-        try:
-            r = requests.get(f"{JUDGE_URL}/result/{sid}", timeout=10)
-            if r.status_code == 200:
-                data = r.json()
-                status = data.get("status")
-                if status in ("done", "error"):
-                    result = data
-                    break
-                if status == "queued":
-                    print(".", end="", flush=True)
-            elif r.status_code == 404:
-                print(".", end="", flush=True)
-        except Exception:
-            pass
-        time.sleep(POLL_INTERVAL)
-
-    print()
-
-    if result is None:
-        print(f"ERROR: Timed out after {MAX_POLL_TIME}s")
-        if write_best_submission_reward("final evaluation timed out"):
+        print(f"ERROR: Evaluation failed: {e}")
+        records = judge_submission_records()
+        write_submissions_log(records)
+        best = best_submission(records)
+        if write_best_submission_reward(f"final evaluation failed: {e}"):
             return
-        write_reward(0.0, "Evaluation timed out")
+        write_reward(0.0, f"Evaluation failed: {e}")
         return
 
-    # 5. Parse result
+    records = judge_submission_records()
+    write_submissions_log(records)
+    best = best_submission(records)
+
+    # 4. Parse result
     if result.get("status") == "error":
         msg = result.get("message") or result.get("error") or "Unknown error"
         print(f"ERROR: {msg}")
@@ -255,7 +227,7 @@ def main():
 
     score = result.get("score") or 0.0  # 0-100
     reward = float(score) / 100.0  # normalize to 0-1
-    unbounded = result.get("scoreUnbounded")
+    unbounded = result.get("score_unbounded")
     if best is not None and float(best.get("score", 0.0)) > reward:
         write_best_submission_reward("final solution scored below best submission")
         return
@@ -280,7 +252,8 @@ def main():
                 "score": score,
                 "score_unbounded": unbounded,
                 "status": result.get("status"),
-                "raw_result": result,
+                "detail": result.get("message") or "",
+                "metrics": result.get("metrics") or {},
             },
             indent=2,
         )

--- a/algorithmic/judge/src/judge_engine.js
+++ b/algorithmic/judge/src/judge_engine.js
@@ -368,7 +368,7 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses based on scoreRatio
-            const finalCases = caseResults.map(caseResult => ({
+            const finalCases = caseResults.map(({ msg, output, ...caseResult }) => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));
@@ -458,7 +458,7 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses for clarity
-            const finalCases = caseResults.map(caseResult => ({
+            const finalCases = caseResults.map(({ msg, output, ...caseResult }) => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));

--- a/algorithmic/judge/src/judge_engine.js
+++ b/algorithmic/judge/src/judge_engine.js
@@ -368,7 +368,7 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses based on scoreRatio
-            const finalCases = caseResults.map(({ msg, output, ...caseResult }) => ({
+            const finalCases = caseResults.map(caseResult => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));
@@ -458,7 +458,7 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses for clarity
-            const finalCases = caseResults.map(({ msg, output, ...caseResult }) => ({
+            const finalCases = caseResults.map(caseResult => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));
@@ -534,4 +534,3 @@ export class JudgeEngine {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

This PR fixes hidden judge-feedback leakage for Harbor algorithmic tasks by moving agent-facing evaluation behind an isolated black-box judge proxy.

Previously, Harbor agents submitted directly to the algorithmic judge and the agent-facing submission path could record the full raw judge result into visible submission logs. For interactive tasks like problem 14, that raw result could include per-case checker/interactor diagnostics such as hidden values in `cases[].msg`.

The fix now mirrors the Frontier-CS 2.0 Harbor evaluation boundary: the agent container can only reach a `judge` sidecar on `http://judge:8082`. That sidecar forwards submissions to the raw algorithmic judge engine on an internal Docker network, waits for completion, and returns only a sanitized aggregate result.

The raw judge engine still captures checker/interactor output internally and still uses it to parse `Ratio:` / `RatioUnbounded:` for scoring. This change fixes the Harbor task boundary rather than relying on stripping internals from the judge engine.

## Bug reproduction: problem 14 leaks hidden data

Problem 14 is an interactive task where the hidden value is the cycle size `n`. A contestant should infer `n` via `walk` queries and then submit `guess g`.

A minimal probe:

```cpp
#include <bits/stdc++.h>
using namespace std;

int main() {
    ios::sync_with_stdio(false);
    cin.tie(nullptr);

    cout << "walk 0" << endl;
    long long s;
    if (!(cin >> s)) return 0;

    const long long MOD = 190000;
    long long extra = s % MOD;
    for (long long i = 0; i < extra; ++i) {
        cout << "walk 0" << endl;
        long long x;
        if (!(cin >> x)) return 0;
    }

    cout << "guess 1" << endl;
    return 0;
}
```

Before this fix, the Harbor agent-facing submission path could receive and log the full raw judge result, including hidden test data in `cases[].msg`:

```text
points 0.0 Wrong answer. hidden n=362380609, your guess=1, queries=187034
points 0.0 Wrong answer. hidden n=104247795, your guess=1, queries=104456
...
```

This was not just visible as passive feedback. The agent could read `/logs/agent/submissions.jsonl`, extract leaked hidden values, and hardcode fixed-case behavior.

## What changed

This PR replaces the Harbor algorithmic submission path with a black-box proxy:

- Adds `judge_proxy.py`, exposed to the agent as `http://judge:8082`
- Keeps the raw algorithmic judge engine on `judge-engine:8081`
- Places `judge-engine` on an internal Docker network that the agent container cannot reach
- Updates agent-facing `submit.py` to call `/evaluate` on the proxy instead of `/submit` + `/result/:sid`
- Updates verifier `evaluate.py` to use the same proxy path
- Records only sanitized submission records in agent/verifier-visible logs
- Stops mounting raw judge-engine submission artifacts to host artifacts by default

The proxy returns only:

```json
{
  "status": "done",
  "score": 55.312,
  "score_unbounded": 55.312,
  "passed": false,
  "message": "Wrong Answer",
  "metrics": {
    "sid": 1,
    "total_cases": 10,
    "perfect_cases": 0
  }
}
```

It does not return:

- `cases`
- `cases[].msg`
- `cases[].output`
- `scoreRatio`
- `scoreRatioUnbounded`
- checker/interactor stdout/stderr
- raw `/result/:sid`

## Impact

Unchanged:

- Raw algorithmic judge scoring logic
- `Ratio:` / `RatioUnbounded:` parsing
- `score`
- `scoreUnbounded`
- pass/fail calculation
- internal judge result generation
- optional raw artifact preservation when explicitly enabled

Changed:

- Harbor agents no longer talk directly to the raw judge engine
- Harbor agents no longer receive raw `/result/:sid`
- `/logs/agent/submissions.jsonl` no longer contains `raw_result`
- verifier-visible submission logs are sanitized
- raw judge-engine artifacts are not mounted to host artifacts by default
- Harbor algorithmic tasks now run `main`, `judge` proxy, and `judge-engine`

## Type of Change

- [ ] New research problem
- [ ] New algorithmic problem
- [ ] New Frontier-CS 2.0 problem
- [x] Bug fix
- [ ] Documentation update
- [ ] Other:

## Testing

Syntax checks:

```bash
python3 -m py_compile \
  adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/adapter.py \
  adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/judge_proxy.py \
  adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/environment/submit.py \
  adapters/frontier-cs-algorithm/src/frontier_cs_algorithm/task-template/tests/evaluate.py

node --check algorithmic/judge/src/judge_engine.js

git diff --check upstream/main...HEAD
```

End-to-end Harbor test on problem 14:

```bash
uv run frontier harbor trial algorithmic 14 \
  --json \
  --agent codex \
  --model gpt-5.5 \
  --agent-timeout 240 \
  --verifier-timeout 280 \
  --force-build \
  --env CODEX_AUTH_JSON_PATH=/home/ubuntu/.codex/auth.json \
  --verbose
```

Observed result:

- trial completed with `trial_status: scored`
- reward: `0.5531200000000001`
- submission feedback exposed to the agent contained only sanitized score/detail/metrics
- no `cases[].msg`, hidden `n=...`, `scoreRatio`, checker output, or raw judge-engine result was visible in agent/verifier logs

Leak scan checked latest trial artifacts for patterns including:

```text
hidden n=
scoreRatio
RatioUnbounded
Wrong answer. hidden
queries=
"msg"
"output"
case_
ans.txt
tout.txt
judge-engine
8081
```

No leaks were found in agent-visible or verifier-visible artifacts.

Network isolation check:

- `main` can reach `judge:8082`
- `main` cannot resolve or reach `judge-engine:8081`

## Checklist

- [x] Code follows the project structure and conventions
- [x] Self-review completed
- [x] Documentation updated if applicable

## CI Validation

N/A. This PR does not add a new problem.