### PR TITLE
Formal conjectures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/formal-conjectures"]
+	path = third_party/formal-conjectures
+	url = https://github.com/google-deepmind/formal-conjectures.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,8 +373,9 @@ release tag; **problem directories are generated from it and are not
 committed** (see the `.gitignore` there). Materialization is automatic: the
 first `frontier list|eval|show` touching these problems initializes the
 submodule and runs the generator (`src/frontier_cs/lazy_problems.py`), stamping
-the submodule commit in `_generator/.generated-ref` so later accesses serve the
-files directly. To materialize manually:
+the submodule commit plus a generator hash in `_generator/.generated-ref` so
+later accesses serve the files directly (and template changes in `generate.py`
+re-materialize automatically). To materialize manually:
 
 ```bash
 git submodule update --init third_party/formal-conjectures
@@ -383,8 +384,17 @@ python3 research/problems/formal_conjectures/_generator/generate.py
 
 - The generator parses the submodule's Lean sources directly (namespaces,
   `@[category ...]` attributes) — no Lean toolchain needed. "Fill-in-the-answer"
-  statements (`answer(sorry)`) are skipped: their elaborated types substitute a
-  placeholder for the unknown answer and would misstate the question.
+  statements (`answer(sorry)`) elaborate with a placeholder (`True` for Props),
+  so the plain "prove this" contract would misstate them. Those of the exact
+  binder-free shape `answer(sorry) ↔ Q` become mode `prove_or_disprove`
+  problems (submit a proof of `Q` or of `¬Q`; the trusted checker extracts `Q`
+  from the compiled `True ↔ Q` type and fails closed on anything else). The
+  rest — value-style answers, statements referencing section `variable`s or
+  sorry-containing defs — are skipped rather than misrepresented. After a
+  submodule bump, validate with
+  `research/problems/formal_conjectures/_generator/shape_check.sh` (requires
+  docker + the eval image): it rechecks every prove-or-disprove target's
+  compiled shape.
 - Solutions are Lean 4 proofs, checked in a Docker image with Lean + Mathlib +
   formal-conjectures prebuilt (`research/problems/formal_conjectures/docker/`).
 - Scoring is binary: 1.0 iff the submitted proof compiles without `sorry`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,11 @@ statement from [google-deepmind/formal-conjectures](https://github.com/google-de
 (categories `research open` and `research solved`). The source of truth is the
 git submodule at `third_party/formal-conjectures`, pinned to a `bench-*`
 release tag; **problem directories are generated from it and are not
-committed** (see the `.gitignore` there). Materialize them once per checkout:
+committed** (see the `.gitignore` there). Materialization is automatic: the
+first `frontier list|eval|show` touching these problems initializes the
+submodule and runs the generator (`src/frontier_cs/lazy_problems.py`), stamping
+the submodule commit in `_generator/.generated-ref` so later accesses serve the
+files directly. To materialize manually:
 
 ```bash
 git submodule update --init third_party/formal-conjectures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,3 +362,44 @@ Please include:
 - Area of expertise
 - Type of contribution (algorithmic/research problem)
 - Brief description of your proposed contribution
+
+## Formal Conjectures (Lean) Problems
+
+`research/problems/formal_conjectures/` hosts one problem per conjecture
+statement from [google-deepmind/formal-conjectures](https://github.com/google-deepmind/formal-conjectures)
+(categories `research open` and `research solved`). The source of truth is the
+git submodule at `third_party/formal-conjectures`, pinned to a `bench-*`
+release tag; **problem directories are generated from it and are not
+committed** (see the `.gitignore` there). Materialize them once per checkout:
+
+```bash
+git submodule update --init third_party/formal-conjectures
+python3 research/problems/formal_conjectures/_generator/generate.py
+```
+
+- The generator parses the submodule's Lean sources directly (namespaces,
+  `@[category ...]` attributes) — no Lean toolchain needed. "Fill-in-the-answer"
+  statements (`answer(sorry)`) are skipped: their elaborated types substitute a
+  placeholder for the unknown answer and would misstate the question.
+- Solutions are Lean 4 proofs, checked in a Docker image with Lean + Mathlib +
+  formal-conjectures prebuilt (`research/problems/formal_conjectures/docker/`).
+- Scoring is binary: 1.0 iff the submitted proof compiles without `sorry`,
+  proves a statement definitionally equal to the conjecture, and uses only the
+  standard axioms. See `research/problems/formal_conjectures/common/`.
+- These problems are **excluded from CI validation** (the `.skip-validation`
+  marker): open conjectures cannot have a reference solution scoring > 0.
+  They are also excluded from `research/scripts/problems.txt` and the README
+  problem count.
+
+To bump the submodule to a new upstream release:
+
+```bash
+git -C third_party/formal-conjectures checkout <new-bench-tag>
+research/problems/formal_conjectures/docker/build.sh --push   # rebuild eval image
+python3 research/problems/formal_conjectures/_generator/generate.py --wipe
+git add third_party/formal-conjectures                        # only the pointer changes
+```
+
+The parser can be cross-checked against upstream's own extractor:
+`docker run --rm <eval-image> lake exe extract_names > /tmp/extract.json`
+then `generate.py --check-against /tmp/extract.json`.

--- a/research/README.md
+++ b/research/README.md
@@ -135,3 +135,29 @@ class Solution:
 
 Check each problem's `readme` for the specific `solve()` signature and return type.
 
+
+## Formal Conjectures (Lean) Problems
+
+`formal_conjectures/<source>/<theorem>` problems ask for a Lean 4 proof of a
+formalized conjecture from
+[google-deepmind/formal-conjectures](https://github.com/google-deepmind/formal-conjectures).
+Problem directories are generated from the `third_party/formal-conjectures`
+submodule and are not committed — materialize them once per checkout:
+
+```bash
+git submodule update --init third_party/formal-conjectures
+python3 research/problems/formal_conjectures/_generator/generate.py
+
+# List them
+uv run frontier list research | grep formal_conjectures
+
+# Evaluate a proof (Docker backend; the image bundles Lean + Mathlib prebuilt)
+uv run frontier eval research formal_conjectures/erdos_problems/Erdos1.erdos_1 \
+    proof.lean --backend docker
+```
+
+A submission is a single Lean file declaring a top-level
+`theorem solution : <exact statement> := <proof>` (see each problem's readme).
+Score is binary: 1.0 iff the proof compiles without `sorry`, the statement
+matches the conjecture up to definitional equality, and no axioms beyond
+`propext`, `Classical.choice`, `Quot.sound` are used.

--- a/research/README.md
+++ b/research/README.md
@@ -142,13 +142,11 @@ Check each problem's `readme` for the specific `solve()` signature and return ty
 formalized conjecture from
 [google-deepmind/formal-conjectures](https://github.com/google-deepmind/formal-conjectures).
 Problem directories are generated from the `third_party/formal-conjectures`
-submodule and are not committed — materialize them once per checkout:
+submodule and are not committed — the framework materializes them
+automatically on first access (list/eval/show):
 
 ```bash
-git submodule update --init third_party/formal-conjectures
-python3 research/problems/formal_conjectures/_generator/generate.py
-
-# List them
+# List them (generates the problem dirs on first run)
 uv run frontier list research | grep formal_conjectures
 
 # Evaluate a proof (Docker backend; the image bundles Lean + Mathlib prebuilt)

--- a/research/problems/formal_conjectures/.gitignore
+++ b/research/problems/formal_conjectures/.gitignore
@@ -1,0 +1,7 @@
+# Problem directories are generated from the third_party/formal-conjectures
+# submodule and are not committed. Materialize them with:
+#   python3 research/problems/formal_conjectures/_generator/generate.py
+/*/
+!/_generator/
+!/common/
+!/docker/

--- a/research/problems/formal_conjectures/.gitignore
+++ b/research/problems/formal_conjectures/.gitignore
@@ -5,3 +5,4 @@
 !/_generator/
 !/common/
 !/docker/
+/_generator/.generated-ref

--- a/research/problems/formal_conjectures/.skip-validation
+++ b/research/problems/formal_conjectures/.skip-validation
@@ -1,0 +1,3 @@
+Problems in this directory are auto-generated Lean proof tasks for open math
+conjectures. Open conjectures cannot have a reference solution scoring > 0,
+so CI reference validation is skipped (see scripts/detect_changed_problems.py).

--- a/research/problems/formal_conjectures/_generator/ShapeCheck.lean
+++ b/research/problems/formal_conjectures/_generator/ShapeCheck.lean
@@ -1,0 +1,47 @@
+/-
+Validation sweep for prove-or-disprove problems (run via shape_check.sh).
+
+Reads a file of lines "<module components> / <theorem components>" and checks,
+in the prebuilt eval environment, that every target's compiled type has the
+exact placeholder shape `True ↔ Q` required by CheckDriver.lean's
+"prove_or_disprove" mode. Any target failing this would be a permanently-zero
+problem (the driver fails closed) and must be excluded by the generator —
+typically because the statement references section `variable`s, which prepend
+∀ binders to the compiled type.
+
+Prints one "BAD <reason>: <name>" line per failure and a final
+"checked <n>, bad <m>" summary; exits non-zero iff any target is bad.
+-/
+import Lean
+open Lean
+
+def mkNameFromComponents (cs : List String) : Name :=
+  cs.foldl .str .anonymous
+
+def main (args : List String) : IO UInt32 := do
+  initSearchPath (← findSysroot)
+  let lines ← IO.FS.lines ⟨args.head!⟩
+  let entries := lines.filterMap fun l =>
+    if l.isEmpty then none
+    else
+      match l.splitOn " / " with
+      | [m, t] => some (mkNameFromComponents (m.splitOn " "),
+                        mkNameFromComponents (t.splitOn " "))
+      | _ => none
+  let mods := entries.map (fun e => ({ module := e.1 } : Import))
+  let env ← importModules mods {}
+  let mut bad := 0
+  let mut total := 0
+  for (_, name) in entries do
+    total := total + 1
+    match env.find? name with
+    | none => IO.println s!"BAD missing: {name}"; bad := bad + 1
+    | some ci =>
+      if ci.type.hasSorry then
+        IO.println s!"BAD hasSorry: {name}"; bad := bad + 1
+      else if !ci.type.isAppOfArity `Iff 2 then
+        IO.println s!"BAD not-iff: {name}"; bad := bad + 1
+      else if !(ci.type.appFn!.appArg!.isConstOf `True) then
+        IO.println s!"BAD lhs-not-True: {name}"; bad := bad + 1
+  IO.println s!"checked {total}, bad {bad}"
+  return if bad == 0 then 0 else 1

--- a/research/problems/formal_conjectures/_generator/generate.py
+++ b/research/problems/formal_conjectures/_generator/generate.py
@@ -658,6 +658,17 @@ def main() -> int:
                 shutil.rmtree(child)
 
     generate(decls, args.out, ref, lean_version, categories, args.only)
+
+    # Stamp the submodule commit so the framework's lazy materialization
+    # (src/frontier_cs/lazy_problems.py) can tell fresh from stale.
+    if not args.only and args.out == PROBLEMS_ROOT:
+        head = subprocess.run(
+            ["git", "-C", str(SUBMODULE), "rev-parse", "HEAD"],
+            capture_output=True, text=True,
+        )
+        if head.returncode == 0:
+            (GENERATOR_DIR / ".generated-ref").write_text(
+                head.stdout.strip() + "\n", encoding="utf-8")
     return 0
 
 

--- a/research/problems/formal_conjectures/_generator/generate.py
+++ b/research/problems/formal_conjectures/_generator/generate.py
@@ -8,7 +8,8 @@ becomes a problem directory:
 
     research/problems/formal_conjectures/<source>/<TheoremName>/
         config.yaml    # identical for all problems
-        evaluate.sh    # identical
+        evaluate.sh    # identical (in-container entrypoint)
+        check.sh       # host-side wrapper: ./check.sh solution.lean scores locally
         evaluator.py   # thin shim importing ../../common/fc_evaluator.py
         target.json    # which module/theorem this problem targets
         readme         # statement, docstring, submission contract
@@ -19,12 +20,17 @@ checkout (and after every submodule bump):
 
     python3 research/problems/formal_conjectures/_generator/generate.py --wipe
 
-Skipped statements: "fill-in-the-answer" conjectures, i.e. any statement that
-uses `answer(sorry)` (directly, or via a same-file definition whose body
-contains `answer(sorry)`/`sorry`). Upstream's `answer()` elaborator substitutes
-a placeholder (`True` for Props) for the unknown answer, so the elaborated type
-misstates the actual question — these need a different check mode ("find the
-answer and prove it") and are excluded rather than misrepresented.
+"Fill-in-the-answer" conjectures — statements using `answer(sorry)` for an
+unknown answer — get special treatment. Upstream's `answer()` elaborator
+substitutes a placeholder (`True` for Props), so their elaborated type
+misstates the question and the plain "prove this statement" contract would be
+unsound. Statements of the exact shape `theorem n : answer(sorry) ↔ Q` become
+mode "prove_or_disprove" problems instead (target.json `mode` field): the task
+is to prove `Q` or `¬Q`, checked by the trusted driver against the compiled
+`True ↔ Q` type. All other answer-style statements (value-style answers,
+ambiguous shapes, statements referencing same-file sorry-defs) remain
+excluded rather than misrepresented — there is no sound automatic check for
+"is this value a genuine answer".
 
 The parser can be cross-checked against the upstream extractor (ground truth
 from the built Lean environment):
@@ -34,6 +40,7 @@ from the built Lean environment):
 """
 
 import argparse
+import hashlib
 import json
 import re
 import shutil
@@ -69,8 +76,36 @@ EVALUATE_SH = """\
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
-SOLUTION_PATH="/work/execution_env/solution_env/solution.lean"
+# Default is the harness layout; override for standalone runs inside the eval
+# image (or just use ./check.sh from the host, which sets this for you).
+SOLUTION_PATH="${SOLUTION_PATH:-/work/execution_env/solution_env/solution.lean}"
 python3 evaluator.py --solution-path "$SOLUTION_PATH" --target target.json
+"""
+
+# Host-side scorer; @IMAGE_REF@ is substituted at generation time (the template
+# is .replace()d, not .format()ted, because of the bash ${...} braces).
+CHECK_SH = """\
+#!/usr/bin/env bash
+# Score a candidate solution for this problem locally. Requires docker and the
+# prebuilt eval image. Prints evaluator diagnostics on stderr; the last stdout
+# line is the score (1.0 accepted / 0.0 rejected). Takes ~2 min (import loading).
+#
+#   ./check.sh path/to/solution.lean
+set -euo pipefail
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+  echo "usage: $0 path/to/solution.lean" >&2
+  exit 2
+fi
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FC_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+REL=${SCRIPT_DIR#"$FC_ROOT"/}
+SOLUTION=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+exec docker run --rm \\
+  -v "$FC_ROOT":/fcp:ro \\
+  -v "$SOLUTION":/sol/solution.lean:ro \\
+  -e SOLUTION_PATH=/sol/solution.lean \\
+  @IMAGE_REF@ \\
+  bash "/fcp/$REL/evaluate.sh"
 """
 
 EVALUATOR_PY = """\
@@ -136,12 +171,131 @@ Binary. Score 1.0 iff:
 Anything else scores 0.0. Not allowed (rejected by lint): `axiom`, `macro`,
 `elab`, `syntax`, `notation`, `initialize`, `run_cmd`, `implemented_by`,
 `extern`, `unsafe`, `native_decide`, `set_option debug.*`.
+
+## Local verification
+
+With docker available, score a candidate from this problem directory:
+
+    ./check.sh path/to/solution.lean
+
+This runs the official evaluator (lint + compile + trusted statement/axiom
+check) inside `{image_ref}`; the last stdout line is the score. A run takes
+~2 minutes, almost all of it Mathlib import loading — so while iterating,
+prefer one compile-only pass over many small ones, batching experimental
+lemmas into a single file:
+
+    docker run --rm -v "$PWD":/sol {image_ref} \\
+      bash -c 'cd /opt/formal-conjectures && lake env lean --root /sol /sol/solution.lean'
+
+Exit code 0 with no output means it compiles (`sorry` still compiles, with a
+warning). Mathlib and formal-conjectures sources are browsable in the image
+under `/opt/formal-conjectures`.
+"""
+
+
+README_POD = """\
+# {theorem}
+
+Formalized fill-in-the-answer conjecture from
+[google-deepmind/formal-conjectures]({upstream}) at
+`{ref}` — source: [`{source_file}`]({upstream}/blob/{ref}/{source_file})
+(vendored at `third_party/formal-conjectures`; Apache-2.0 / CC-BY).
+
+- Category: {category}
+- AMS subjects: {subjects}
+- Mode: prove or disprove
+
+## Statement
+{docstring_section}
+The upstream statement leaves its truth value open — `answer(sorry)` marks
+the unknown answer:
+
+```lean
+{statement} := by
+  sorry
+```
+
+The question, `Q`, is the right-hand side of the iff:
+
+```lean
+Q := {question}
+```
+
+(In the prebuilt environment the `answer(sorry)` placeholder elaborates to
+`True`, so the declared statement reads `True ↔ Q`. Do **not** prove that —
+it misstates the question and scores 0.0.)
+{namespace_note}
+## Task
+
+Determine whether `Q` is true or false, and prove your answer. Submit **one
+Lean 4 file** that:
+
+1. Imports the module containing the statement (plus anything else you need
+   from Mathlib):
+
+   ```lean
+   import {module_dotted}
+   ```
+
+2. Declares a **top-level** theorem named `solution` proving either `Q` or
+   `¬Q` (you may `open` the relevant namespaces, or use any definitionally
+   equal form):
+
+   ```lean
+   theorem solution : <Q> := <your proof>       -- claiming the answer is yes
+   -- or
+   theorem solution : ¬(<Q>) := <your proof>    -- claiming the answer is no
+   ```
+
+## Scoring
+
+Binary. Score 1.0 iff:
+
+- the file compiles against Lean {lean_version} + Mathlib + formal-conjectures
+  `{ref}` (the exact prebuilt environment is in the evaluation image),
+- it contains no `sorry` / `admit`,
+- the type of `solution` is definitionally equal to `Q` or to `¬Q`, where the
+  trusted checker extracts `Q` from the compiled statement of `{theorem}`, and
+- `solution` depends on no axioms beyond `propext`, `Classical.choice`,
+  `Quot.sound`.
+
+Anything else — including anything the trusted checker cannot positively
+verify — scores 0.0. Not allowed (rejected by lint): `axiom`, `macro`,
+`elab`, `syntax`, `notation`, `initialize`, `run_cmd`, `implemented_by`,
+`extern`, `unsafe`, `native_decide`, `set_option debug.*`.
+
+## Local verification
+
+With docker available, score a candidate from this problem directory:
+
+    ./check.sh path/to/solution.lean
+
+This runs the official evaluator (lint + compile + trusted statement/axiom
+check) inside `{image_ref}`; the last stdout line is the score. A run takes
+~2 minutes, almost all of it Mathlib import loading — so while iterating,
+prefer one compile-only pass over many small ones, batching experimental
+lemmas into a single file:
+
+    docker run --rm -v "$PWD":/sol {image_ref} \\
+      bash -c 'cd /opt/formal-conjectures && lake env lean --root /sol /sol/solution.lean'
+
+Exit code 0 with no output means it compiles (`sorry` still compiles, with a
+warning). Mathlib and formal-conjectures sources are browsable in the image
+under `/opt/formal-conjectures`.
 """
 
 
 # --------------------------------------------------------------------------
 # Lean source parsing
 # --------------------------------------------------------------------------
+
+# Exact fill-in-the-answer shape rescuable as prove-or-disprove: the statement
+# is a binder-free top-level `answer(sorry) ↔ Q`. (Trailing `Q ↔ answer(sorry)`
+# is textually ambiguous with `∀ x, (P x ↔ answer(sorry))` and is not rescued.)
+ANSWER_IFF_RE = re.compile(
+    r"(?s)\b(?:theorem|lemma)\s+[^\s:({\[⦃⟨]+\s*:\s*"
+    r"answer\(\s*sorry\s*\)\s*↔\s*(.+)$"
+)
 
 DECL_RE = re.compile(
     r"^(?:private\s+|protected\s+|noncomputable\s+)*(?:theorem|lemma)\s+"
@@ -157,6 +311,7 @@ ANON_INSTANCE_RE = re.compile(
 NAMESPACE_RE = re.compile(r"^namespace\s+(\S+)")
 SECTION_RE = re.compile(r"^(?:noncomputable\s+)?section\b")
 END_RE = re.compile(r"^end\b")
+VARIABLE_RE = re.compile(r"^variables?\b")
 OPEN_BRACKETS = "([{⟨⦃"
 CLOSE_BRACKETS = ")]}⟩⦄"
 
@@ -171,6 +326,8 @@ class Decl:
     module_components: list
     source_file: str
     skip_answer_style: bool
+    answer_taint: bool = False  # statement references same-file sorry-defs
+    uses_section_vars: bool = False  # statement references in-scope `variable`s
 
     @property
     def full_name(self) -> str:
@@ -338,6 +495,32 @@ def parse_attr_list(attr_text: str) -> list:
     return parts
 
 
+def extract_binder_names(text: str) -> list:
+    """Names bound by a `variable ...` declaration: for each top-level binder
+    group, the identifiers before its `:`. Groups with no `:` (anonymous
+    instance binders like `[Fintype V]`) bind no names."""
+    text = re.sub(r"^\s*variables?\b", "", text.strip())
+    names, depth, buf = [], 0, None
+    for ch in text:
+        if ch in OPEN_BRACKETS:
+            depth += 1
+            if depth == 1:
+                buf = []
+                continue
+        elif ch in CLOSE_BRACKETS:
+            depth -= 1
+            if depth == 0:
+                buf = None
+            continue
+        if depth == 1 and buf is not None:
+            if ch == ":":
+                names += "".join(buf).split()
+                buf = None
+            else:
+                buf.append(ch)
+    return [n for n in names if re.fullmatch(r"[^\W\d][\w']*", n)]
+
+
 def find_tainted_defs(code_lines: list) -> set:
     """Names of same-file `def`/`abbrev` declarations whose body contains
     `answer(` or `sorry` — statements referencing them are fill-in-the-answer
@@ -365,6 +548,7 @@ def parse_lean_file(path: Path, submodule: Path) -> list:
 
     decls = []
     scope = []                  # ("ns", [components]) | ("sec", None)
+    var_stack = [[]]            # variable names bound per scope frame
     pending_attrs = []          # accumulated @[...] attribute strings
     pending_doc = ""
     attr_buf = None             # multi-line @[...] accumulator
@@ -396,15 +580,24 @@ def parse_lean_file(path: Path, submodule: Path) -> list:
         m = NAMESPACE_RE.match(code)
         if m:
             scope.append(("ns", split_name(m.group(1))))
+            var_stack.append([])
             pending_attrs = []
             continue
         if SECTION_RE.match(code):
             scope.append(("sec", None))
+            var_stack.append([])
             pending_attrs = []
             continue
         if END_RE.match(code):
             if scope:
                 scope.pop()
+            if len(var_stack) > 1:
+                var_stack.pop()
+            pending_attrs = []
+            continue
+        if VARIABLE_RE.match(code):
+            var_stack[-1].extend(
+                extract_binder_names(capture_decl_text(code_lines, idx)))
             pending_attrs = []
             continue
 
@@ -432,13 +625,17 @@ def parse_lean_file(path: Path, submodule: Path) -> list:
                     continue
                 statement_body = capture_statement(code_lines, idx)
                 decl_text = capture_decl_text(code_lines, idx)
-                answer_style = bool(
-                    re.search(r"\banswer\(\s*[^)]*\bsorry\b", decl_text)
-                ) or any(
+                taint = any(
                     re.search(rf"(?<![A-Za-z0-9_']){re.escape(t)}(?![A-Za-z0-9_'])",
                               statement_body)
                     for t in tainted
                 )
+                answer_style = taint or bool(
+                    re.search(r"\banswer\(\s*[^)]*\bsorry\b", decl_text)
+                )
+                stmt_tokens = set(re.findall(r"[^\W\d][\w']*", statement_body))
+                uses_vars = any(
+                    v in stmt_tokens for frame in var_stack for v in frame)
                 statement = ("@[" + ", ".join(attr_display) + "]\n" if attr_display else "") \
                     + statement_body
                 decls.append(Decl(
@@ -450,6 +647,8 @@ def parse_lean_file(path: Path, submodule: Path) -> list:
                     module_components=module_components,
                     source_file=source_file,
                     skip_answer_style=answer_style,
+                    answer_taint=taint,
+                    uses_section_vars=uses_vars,
                 ))
             pending_attrs = []
             continue
@@ -477,9 +676,38 @@ def parse_all(submodule: Path) -> list:
 # Generation
 # --------------------------------------------------------------------------
 
+def answer_iff_question(decl: Decl):
+    """Textual `Q` for fill-in-the-answer statements of the exact rescuable
+    shape `theorem <name> : answer(sorry) ↔ Q` — binder-free, exactly one
+    `answer()`/`sorry`, and no same-file sorry-def references. None otherwise.
+
+    This gate is presentation-side only; the trusted checker independently
+    verifies the compiled statement has the `True ↔ Q` placeholder shape and
+    fails closed (0.0) on anything it cannot positively verify.
+
+    Statements referencing section `variable`s are not rescuable: the compiled
+    type gains leading ∀ binders (`∀ vars, True ↔ Q`), which both breaks the
+    top-level-iff shape and makes prove-or-disprove semantically ambiguous
+    (the answer could differ per instantiation). Validate any change here with
+    _generator/shape_check.sh, which checks every generated prove-or-disprove
+    target's compiled type in the eval image.
+    """
+    if decl.answer_taint or decl.uses_section_vars:
+        return None
+    if decl.statement.count("answer(") != 1:
+        return None
+    if len(re.findall(r"\bsorry\b", decl.statement)) != 1:
+        return None
+    m = ANSWER_IFF_RE.search(decl.statement)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
 def generate(decls: list, out: Path, ref: str, lean_version: str,
              categories: set, only: str) -> None:
     generated, skipped_answer, by_category = [], [], {}
+    n_pod = 0
     seen_dirs = set()
 
     for decl in sorted(decls, key=lambda d: (d.source_file, d.full_name)):
@@ -489,9 +717,12 @@ def generate(decls: list, out: Path, ref: str, lean_version: str,
         elif decl.category not in categories:
             continue
 
+        question = None
         if decl.skip_answer_style:
-            skipped_answer.append(decl.full_name)
-            continue
+            question = answer_iff_question(decl)
+            if question is None:
+                skipped_answer.append(decl.full_name)
+                continue
 
         source = snake(decl.module_components[1]) if len(decl.module_components) > 1 else "misc"
         dir_name = ".".join(sanitize(c) for c in decl.full_name_components)
@@ -522,47 +753,54 @@ def generate(decls: list, out: Path, ref: str, lean_version: str,
         (problem_dir / "config.yaml").write_text(
             CONFIG_YAML.format(ref=ref, image=IMAGE), encoding="utf-8")
         (problem_dir / "evaluate.sh").write_text(EVALUATE_SH, encoding="utf-8")
+        (problem_dir / "check.sh").write_text(
+            CHECK_SH.replace("@IMAGE_REF@", f"{IMAGE}:{ref}"), encoding="utf-8")
         (problem_dir / "evaluator.py").write_text(EVALUATOR_PY, encoding="utf-8")
+        target = {
+            "module": decl.module_components,
+            "theorem": decl.full_name_components,
+            "category": decl.category,
+            "subjects": decl.subjects,
+            "source_file": decl.source_file,
+            "ref": ref,
+        }
+        if question is not None:
+            target["mode"] = "prove_or_disprove"
         (problem_dir / "target.json").write_text(
-            json.dumps(
-                {
-                    "module": decl.module_components,
-                    "theorem": decl.full_name_components,
-                    "category": decl.category,
-                    "subjects": decl.subjects,
-                    "source_file": decl.source_file,
-                    "ref": ref,
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
+            json.dumps(target, indent=2) + "\n", encoding="utf-8",
         )
-        (problem_dir / "readme").write_text(
-            README.format(
-                theorem=decl.full_name,
-                upstream=UPSTREAM,
-                ref=ref,
-                source_file=decl.source_file,
-                category=decl.category,
-                subjects=", ".join(decl.subjects) or "-",
-                statement=decl.statement,
-                docstring_section=docstring_section,
-                namespace_note=namespace_note,
-                module_dotted=module_dotted,
-                lean_version=lean_version,
-            ),
-            encoding="utf-8",
+        readme_kwargs = dict(
+            theorem=decl.full_name,
+            upstream=UPSTREAM,
+            ref=ref,
+            source_file=decl.source_file,
+            category=decl.category,
+            subjects=", ".join(decl.subjects) or "-",
+            statement=decl.statement,
+            docstring_section=docstring_section,
+            namespace_note=namespace_note,
+            module_dotted=module_dotted,
+            lean_version=lean_version,
+            image_ref=f"{IMAGE}:{ref}",
         )
+        if question is None:
+            readme = README.format(**readme_kwargs)
+        else:
+            readme = README_POD.format(question=question, **readme_kwargs)
+            n_pod += 1
+        (problem_dir / "readme").write_text(readme, encoding="utf-8")
         (problem_dir / "evaluate.sh").chmod(0o755)
+        (problem_dir / "check.sh").chmod(0o755)
 
         generated.append(decl.full_name)
         by_category[decl.category] = by_category.get(decl.category, 0) + 1
 
-    print(f"generated {len(generated)} problems into {out}")
+    print(f"generated {len(generated)} problems into {out} "
+          f"({len(generated) - n_pod} prove, {n_pod} prove-or-disprove)")
     for cat, n in sorted(by_category.items()):
         print(f"  {cat}: {n}")
-    print(f"skipped {len(skipped_answer)} fill-in-the-answer (answer(sorry)) statements")
+    print(f"skipped {len(skipped_answer)} answer-style statements with no sound "
+          "check mode (value-style, ambiguous shape, or sorry-def taint)")
 
 
 def check_against(decls: list, extractor_json: Path, categories: set) -> int:
@@ -616,6 +854,13 @@ def check_against(decls: list, extractor_json: Path, categories: set) -> int:
     return 0 if ok else 1
 
 
+def generation_stamp(submodule_head: str) -> str:
+    """Stamp identifying what generated dirs were produced from. Must stay in
+    sync with the reimplementation in src/frontier_cs/lazy_problems.py."""
+    ghash = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:16]
+    return f"{submodule_head}+{ghash}"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", type=Path, default=PROBLEMS_ROOT,
@@ -659,8 +904,9 @@ def main() -> int:
 
     generate(decls, args.out, ref, lean_version, categories, args.only)
 
-    # Stamp the submodule commit so the framework's lazy materialization
-    # (src/frontier_cs/lazy_problems.py) can tell fresh from stale.
+    # Stamp submodule commit + generator hash so the framework's lazy
+    # materialization (src/frontier_cs/lazy_problems.py) regenerates when
+    # either the sources or the templates change.
     if not args.only and args.out == PROBLEMS_ROOT:
         head = subprocess.run(
             ["git", "-C", str(SUBMODULE), "rev-parse", "HEAD"],
@@ -668,7 +914,7 @@ def main() -> int:
         )
         if head.returncode == 0:
             (GENERATOR_DIR / ".generated-ref").write_text(
-                head.stdout.strip() + "\n", encoding="utf-8")
+                generation_stamp(head.stdout.strip()) + "\n", encoding="utf-8")
     return 0
 
 

--- a/research/problems/formal_conjectures/_generator/generate.py
+++ b/research/problems/formal_conjectures/_generator/generate.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""
+Generate one Frontier-CS research problem per formal-conjectures statement,
+directly from the third_party/formal-conjectures submodule sources.
+
+Each theorem tagged `@[category research open]` or `@[category research solved]`
+becomes a problem directory:
+
+    research/problems/formal_conjectures/<source>/<TheoremName>/
+        config.yaml    # identical for all problems
+        evaluate.sh    # identical
+        evaluator.py   # thin shim importing ../../common/fc_evaluator.py
+        target.json    # which module/theorem this problem targets
+        readme         # statement, docstring, submission contract
+
+Generated directories are NOT committed (see ../.gitignore): the submodule is
+the source of truth and generation is deterministic. Run this script once per
+checkout (and after every submodule bump):
+
+    python3 research/problems/formal_conjectures/_generator/generate.py --wipe
+
+Skipped statements: "fill-in-the-answer" conjectures, i.e. any statement that
+uses `answer(sorry)` (directly, or via a same-file definition whose body
+contains `answer(sorry)`/`sorry`). Upstream's `answer()` elaborator substitutes
+a placeholder (`True` for Props) for the unknown answer, so the elaborated type
+misstates the actual question — these need a different check mode ("find the
+answer and prove it") and are excluded rather than misrepresented.
+
+The parser can be cross-checked against the upstream extractor (ground truth
+from the built Lean environment):
+
+    docker run --rm <eval-image> lake exe extract_names > /tmp/extract.json
+    python3 generate.py --check-against /tmp/extract.json
+"""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+GENERATOR_DIR = Path(__file__).resolve().parent
+PROBLEMS_ROOT = GENERATOR_DIR.parent          # research/problems/formal_conjectures
+REPO_ROOT = PROBLEMS_ROOT.parents[2]
+SUBMODULE = REPO_ROOT / "third_party" / "formal-conjectures"
+UPSTREAM = "https://github.com/google-deepmind/formal-conjectures"
+
+DEFAULT_CATEGORIES = ("research open", "research solved")
+IMAGE = "shangyint/formal-conjectures-eval"
+
+CONFIG_YAML = """\
+tag: math
+runtime:
+  language: lean
+  timeout_seconds: 1800
+  environment: "Lean 4 + Mathlib + formal-conjectures ({ref}), prebuilt at /opt/formal-conjectures"
+  docker:
+    image: {image}:{ref}
+  resources:
+    cpus: "8"
+    memory: "32"
+"""
+
+EVALUATE_SH = """\
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+SOLUTION_PATH="/work/execution_env/solution_env/solution.lean"
+python3 evaluator.py --solution-path "$SOLUTION_PATH" --target target.json
+"""
+
+EVALUATOR_PY = """\
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "common"))
+
+from fc_evaluator import main
+
+if __name__ == "__main__":
+    main()
+"""
+
+README = """\
+# {theorem}
+
+Formalized conjecture from [google-deepmind/formal-conjectures]({upstream}) at
+`{ref}` — source: [`{source_file}`]({upstream}/blob/{ref}/{source_file})
+(vendored at `third_party/formal-conjectures`; Apache-2.0 / CC-BY).
+
+- Category: {category}
+- AMS subjects: {subjects}
+
+## Statement
+{docstring_section}
+```lean
+{statement} := by
+  sorry
+```
+{namespace_note}
+## Task
+
+Prove this statement. Submit **one Lean 4 file** that:
+
+1. Imports the module containing the statement (plus anything else you need
+   from Mathlib):
+
+   ```lean
+   import {module_dotted}
+   ```
+
+2. Declares a **top-level** theorem named `solution` whose statement is
+   *exactly* the statement above (you may `open` the relevant namespaces, or
+   restate it in any definitionally equal form):
+
+   ```lean
+   theorem solution : <statement> := <your proof>
+   ```
+
+## Scoring
+
+Binary. Score 1.0 iff:
+
+- the file compiles against Lean {lean_version} + Mathlib + formal-conjectures
+  `{ref}` (the exact prebuilt environment is in the evaluation image),
+- it contains no `sorry` / `admit`,
+- the type of `solution` is definitionally equal to the statement of
+  `{theorem}`, and
+- `solution` depends on no axioms beyond `propext`, `Classical.choice`,
+  `Quot.sound`.
+
+Anything else scores 0.0. Not allowed (rejected by lint): `axiom`, `macro`,
+`elab`, `syntax`, `notation`, `initialize`, `run_cmd`, `implemented_by`,
+`extern`, `unsafe`, `native_decide`, `set_option debug.*`.
+"""
+
+
+# --------------------------------------------------------------------------
+# Lean source parsing
+# --------------------------------------------------------------------------
+
+DECL_RE = re.compile(
+    r"^(?:private\s+|protected\s+|noncomputable\s+)*(?:theorem|lemma)\s+"
+    r"([^\s:({\[⦃⟨]+)"
+)
+DEF_RE = re.compile(
+    r"^(?:private\s+|protected\s+|noncomputable\s+)*(?:def|abbrev)\s+"
+    r"([^\s:({\[⦃⟨]+)"
+)
+ANON_INSTANCE_RE = re.compile(
+    r"^(?:private\s+|protected\s+|noncomputable\s+)*instance\b"
+)
+NAMESPACE_RE = re.compile(r"^namespace\s+(\S+)")
+SECTION_RE = re.compile(r"^(?:noncomputable\s+)?section\b")
+END_RE = re.compile(r"^end\b")
+OPEN_BRACKETS = "([{⟨⦃"
+CLOSE_BRACKETS = ")]}⟩⦄"
+
+
+@dataclass
+class Decl:
+    full_name_components: list
+    category: str
+    subjects: list
+    statement: str          # attr line(s) + signature, proof stripped
+    docstring: str
+    module_components: list
+    source_file: str
+    skip_answer_style: bool
+
+    @property
+    def full_name(self) -> str:
+        return ".".join(self.full_name_components)
+
+
+def split_name(dotted: str) -> list:
+    """Split a Lean dotted name into components, honoring «...» quoting."""
+    components, buf, depth = [], [], 0
+    for ch in dotted:
+        if ch == "«":
+            depth += 1
+        elif ch == "»":
+            depth -= 1
+        elif ch == "." and depth == 0:
+            components.append("".join(buf))
+            buf = []
+            continue
+        else:
+            buf.append(ch)
+    components.append("".join(buf))
+    return components
+
+
+def is_internal(components: list) -> bool:
+    """Mirror upstream extract_names: names with `_`/`match_`/`proof_`-prefixed
+    components are auxiliary declarations, not benchmark statements."""
+    return any(c.startswith(("_", "match_", "proof_")) for c in components)
+
+
+def snake(name: str) -> str:
+    """CamelCase source dir -> snake_case problem dir (ErdosProblems -> erdos_problems)."""
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", name)
+    return s.lower()
+
+
+def sanitize(component: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_']", "_", component)
+
+
+def consume_block_comment(s: str, depth: int):
+    """Consume a (nesting) block comment. Returns (remainder, new_depth)."""
+    pos = 0
+    while depth > 0:
+        opener = s.find("/-", pos)
+        closer = s.find("-/", pos)
+        if opener != -1 and (closer == -1 or opener < closer):
+            depth += 1
+            pos = opener + 2
+        elif closer != -1:
+            depth -= 1
+            pos = closer + 2
+        else:
+            return "", depth
+    return s[pos:], 0
+
+
+class LineCleaner:
+    """Strips comments from source lines while capturing docstrings, across
+    lines. Feed raw lines; get back the code content of each line."""
+
+    def __init__(self):
+        self.comment_depth = 0
+        self.docstring_open = None      # accumulating /-- ... -/ lines
+        self.last_docstring = ""
+
+    def feed(self, raw: str) -> str:
+        s = raw
+        if self.docstring_open is not None:
+            if "-/" not in s:
+                self.docstring_open.append(raw)
+                return ""
+            before, s = s.split("-/", 1)
+            self.docstring_open.append(before)
+            self.last_docstring = "\n".join(self.docstring_open).strip()
+            self.docstring_open = None
+        if self.comment_depth > 0:
+            s, self.comment_depth = consume_block_comment(s, self.comment_depth)
+            if self.comment_depth > 0:
+                return ""
+
+        out = []
+        j = 0
+        while j < len(s):
+            if s[j : j + 2] == "--":
+                break
+            if s[j : j + 3] == "/--":
+                end = s.find("-/", j + 3)
+                if end == -1:
+                    self.docstring_open = [s[j + 3 :]]
+                    break
+                self.last_docstring = s[j + 3 : end].strip()
+                j = end + 2
+                continue
+            if s[j : j + 2] == "/-":
+                rest, self.comment_depth = consume_block_comment(s[j + 2 :], 1)
+                if self.comment_depth > 0:
+                    break
+                s = rest
+                j = 0
+                continue
+            out.append(s[j])
+            j += 1
+        return "".join(out)
+
+
+def clean_lines(text: str):
+    """Return (code_lines, docstring_before_line) for a Lean source text."""
+    cleaner = LineCleaner()
+    code_lines, doc_map = [], []
+    for raw in text.split("\n"):
+        doc_map.append(cleaner.last_docstring)
+        code_lines.append(cleaner.feed(raw))
+    return code_lines, doc_map
+
+
+def capture_statement(code_lines: list, start: int) -> str:
+    """Capture a declaration's signature from `code_lines[start]` up to
+    (excluding) the first `:=` at bracket depth 0. Note: `let x := e` inside a
+    statement type will truncate the capture early — acceptable, the capture is
+    for display only and the readme links to the full source."""
+    captured, depth = [], 0
+    for code in code_lines[start : start + 80]:
+        i = 0
+        while i < len(code):
+            ch = code[i]
+            if ch in OPEN_BRACKETS:
+                depth += 1
+            elif ch in CLOSE_BRACKETS:
+                depth -= 1
+            elif ch == ":" and depth == 0 and code[i : i + 2] == ":=":
+                captured.append(code[:i].rstrip())
+                return "\n".join(c for c in captured if c.strip()).rstrip()
+            i += 1
+        captured.append(code.rstrip())
+    return "\n".join(c for c in captured if c.strip()).rstrip()
+
+
+def capture_decl_text(code_lines: list, start: int) -> str:
+    """Full text of a top-level declaration: from its first line until the next
+    column-0 code line (or EOF)."""
+    chunk = [code_lines[start]]
+    for code in code_lines[start + 1 :]:
+        if code and not code[0].isspace():
+            break
+        chunk.append(code)
+    return "\n".join(chunk)
+
+
+def parse_attr_list(attr_text: str) -> list:
+    """Split the inside of an @[...] block on top-level commas."""
+    parts, buf, depth = [], [], 0
+    for ch in attr_text:
+        if ch in OPEN_BRACKETS:
+            depth += 1
+        elif ch in CLOSE_BRACKETS:
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf).strip())
+    return parts
+
+
+def find_tainted_defs(code_lines: list) -> set:
+    """Names of same-file `def`/`abbrev` declarations whose body contains
+    `answer(` or `sorry` — statements referencing them are fill-in-the-answer
+    style (their elaborated type embeds a placeholder)."""
+    tainted = set()
+    for idx, code in enumerate(code_lines):
+        stripped = code.strip()
+        m = DEF_RE.match(stripped)
+        if not m:
+            continue
+        body = capture_decl_text(code_lines, idx)
+        if re.search(r"\banswer\(|\bsorry\b", body):
+            tainted.add(split_name(m.group(1))[-1])
+    return tainted
+
+
+def parse_lean_file(path: Path, submodule: Path) -> list:
+    """Extract categorized theorem declarations from one Lean source file."""
+    rel = path.relative_to(submodule)
+    module_components = list(rel.with_suffix("").parts)
+    source_file = str(rel)
+    text = path.read_text(encoding="utf-8")
+    code_lines, doc_map = clean_lines(text)
+    tainted = find_tainted_defs(code_lines)
+
+    decls = []
+    scope = []                  # ("ns", [components]) | ("sec", None)
+    pending_attrs = []          # accumulated @[...] attribute strings
+    pending_doc = ""
+    attr_buf = None             # multi-line @[...] accumulator
+
+    for idx, code_raw in enumerate(code_lines):
+        code = code_raw.strip()
+        if not code:
+            continue
+
+        if attr_buf is not None:
+            attr_buf.append(code)
+            joined = " ".join(attr_buf)
+            if joined.count("[") == joined.count("]"):
+                pending_attrs.append(joined)
+                attr_buf = None
+            continue
+        if code.startswith("@["):
+            pending_doc = doc_map[idx]
+            if code.count("[") == code.count("]"):
+                pending_attrs.append(code)
+                after = code[code.rindex("]") + 1 :].strip()
+                if not after:
+                    continue
+                code = after        # attribute and declaration on one line
+            else:
+                attr_buf = [code]
+                continue
+
+        m = NAMESPACE_RE.match(code)
+        if m:
+            scope.append(("ns", split_name(m.group(1))))
+            pending_attrs = []
+            continue
+        if SECTION_RE.match(code):
+            scope.append(("sec", None))
+            pending_attrs = []
+            continue
+        if END_RE.match(code):
+            if scope:
+                scope.pop()
+            pending_attrs = []
+            continue
+
+        m = DECL_RE.match(code)
+        if m:
+            category, subjects, attr_display = None, [], []
+            for attr in pending_attrs:
+                inner = attr.strip()
+                if inner.startswith("@[") and inner.endswith("]"):
+                    inner = inner[2:-1]
+                for part in parse_attr_list(inner):
+                    cm = re.match(r"category\s+(research\s+(?:open|solved)|test|API|textbook)", part)
+                    if cm:
+                        category = re.sub(r"\s+", " ", cm.group(1))
+                        attr_display.append(part)
+                    am = re.match(r"AMS((?:\s+\d+)+)$", part)
+                    if am:
+                        subjects = am.group(1).split()
+                        attr_display.append(part)
+            if category is not None:
+                ns_components = [c for kind, comps in scope if kind == "ns" for c in comps]
+                name_components = ns_components + split_name(m.group(1))
+                if is_internal(name_components):
+                    pending_attrs = []
+                    continue
+                statement_body = capture_statement(code_lines, idx)
+                decl_text = capture_decl_text(code_lines, idx)
+                answer_style = bool(
+                    re.search(r"\banswer\(\s*[^)]*\bsorry\b", decl_text)
+                ) or any(
+                    re.search(rf"(?<![A-Za-z0-9_']){re.escape(t)}(?![A-Za-z0-9_'])",
+                              statement_body)
+                    for t in tainted
+                )
+                statement = ("@[" + ", ".join(attr_display) + "]\n" if attr_display else "") \
+                    + statement_body
+                decls.append(Decl(
+                    full_name_components=name_components,
+                    category=category,
+                    subjects=subjects,
+                    statement=statement,
+                    docstring=doc_map[idx] if doc_map[idx] else pending_doc,
+                    module_components=module_components,
+                    source_file=source_file,
+                    skip_answer_style=answer_style,
+                ))
+            pending_attrs = []
+            continue
+
+        if ANON_INSTANCE_RE.match(code) and any(
+            "category research" in a for a in pending_attrs
+        ):
+            print(f"WARNING: {source_file}:{idx + 1}: anonymous `instance` with a "
+                  "research category attribute cannot be targeted by name; skipped",
+                  file=sys.stderr)
+
+        pending_attrs = []
+
+    return decls
+
+
+def parse_all(submodule: Path) -> list:
+    decls = []
+    for lean_file in sorted((submodule / "FormalConjectures").rglob("*.lean")):
+        decls.extend(parse_lean_file(lean_file, submodule))
+    return decls
+
+
+# --------------------------------------------------------------------------
+# Generation
+# --------------------------------------------------------------------------
+
+def generate(decls: list, out: Path, ref: str, lean_version: str,
+             categories: set, only: str) -> None:
+    generated, skipped_answer, by_category = [], [], {}
+    seen_dirs = set()
+
+    for decl in sorted(decls, key=lambda d: (d.source_file, d.full_name)):
+        if only:
+            if decl.full_name != only:
+                continue
+        elif decl.category not in categories:
+            continue
+
+        if decl.skip_answer_style:
+            skipped_answer.append(decl.full_name)
+            continue
+
+        source = snake(decl.module_components[1]) if len(decl.module_components) > 1 else "misc"
+        dir_name = ".".join(sanitize(c) for c in decl.full_name_components)
+        problem_dir = out / source / dir_name
+
+        if str(problem_dir) in seen_dirs:
+            print(f"WARNING: duplicate problem dir {problem_dir}, skipping {decl.full_name}",
+                  file=sys.stderr)
+            continue
+        seen_dirs.add(str(problem_dir))
+
+        module_dotted = ".".join(
+            c if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_']*", c) else f"«{c}»"
+            for c in decl.module_components
+        )
+        namespace_note = ""
+        if len(decl.full_name_components) > 1:
+            ns_prefix = decl.full_name_components[0]
+            namespace_note = (
+                f"\nThe statement lives in namespace `{ns_prefix}` "
+                f"(fully-qualified name: `{decl.full_name}`); "
+                f"`open {ns_prefix} in` may be convenient.\n"
+            )
+
+        docstring_section = f"\n{decl.docstring}\n" if decl.docstring else ""
+
+        problem_dir.mkdir(parents=True, exist_ok=True)
+        (problem_dir / "config.yaml").write_text(
+            CONFIG_YAML.format(ref=ref, image=IMAGE), encoding="utf-8")
+        (problem_dir / "evaluate.sh").write_text(EVALUATE_SH, encoding="utf-8")
+        (problem_dir / "evaluator.py").write_text(EVALUATOR_PY, encoding="utf-8")
+        (problem_dir / "target.json").write_text(
+            json.dumps(
+                {
+                    "module": decl.module_components,
+                    "theorem": decl.full_name_components,
+                    "category": decl.category,
+                    "subjects": decl.subjects,
+                    "source_file": decl.source_file,
+                    "ref": ref,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (problem_dir / "readme").write_text(
+            README.format(
+                theorem=decl.full_name,
+                upstream=UPSTREAM,
+                ref=ref,
+                source_file=decl.source_file,
+                category=decl.category,
+                subjects=", ".join(decl.subjects) or "-",
+                statement=decl.statement,
+                docstring_section=docstring_section,
+                namespace_note=namespace_note,
+                module_dotted=module_dotted,
+                lean_version=lean_version,
+            ),
+            encoding="utf-8",
+        )
+        (problem_dir / "evaluate.sh").chmod(0o755)
+
+        generated.append(decl.full_name)
+        by_category[decl.category] = by_category.get(decl.category, 0) + 1
+
+    print(f"generated {len(generated)} problems into {out}")
+    for cat, n in sorted(by_category.items()):
+        print(f"  {cat}: {n}")
+    print(f"skipped {len(skipped_answer)} fill-in-the-answer (answer(sorry)) statements")
+
+
+def check_against(decls: list, extractor_json: Path, categories: set) -> int:
+    """Diff the parser's output against `lake exe extract_names` ground truth.
+
+    Pass criteria:
+      - the (name, category) sets agree, except for warned anonymous instances
+        that appear only on the extractor side;
+      - every statement whose *elaborated type* contains sorry per the
+        extractor is also skipped by the parser (the parser intentionally
+        skips MORE: `answer(sorry)` Props elaborate to a `True` placeholder
+        that the extractor cannot distinguish from a real statement).
+    """
+    data = json.loads(extractor_json.read_text(encoding="utf-8"))
+    entries = data["problems"] if isinstance(data, dict) else data
+
+    def norm(name: str) -> str:
+        return ".".join(split_name(name))
+
+    truth = {norm(e["theorem"]): e["category"] for e in entries
+             if e["category"] in categories}
+    mine = {d.full_name: d.category for d in decls if d.category in categories}
+
+    missing = sorted(set(truth) - set(mine))
+    extra = sorted(set(mine) - set(truth))
+    miscat = sorted(n for n in set(truth) & set(mine) if truth[n] != mine[n])
+
+    print(f"extractor: {len(truth)}  parser: {len(mine)}")
+    for label, names in [("MISSING (in extractor, not parsed)", missing),
+                         ("EXTRA (parsed, not in extractor)", extra),
+                         ("CATEGORY MISMATCH", miscat)]:
+        print(f"{label}: {len(names)}")
+        for n in names[:20]:
+            print(f"  - {n}")
+
+    truth_sorry = {norm(e["theorem"]) for e in entries
+                   if e["category"] in categories
+                   and re.search(r"\bsorry(Ax)?\b", e.get("statement", ""))}
+    mine_sorry = {d.full_name for d in decls
+                  if d.category in categories and d.skip_answer_style}
+    uncovered = sorted(truth_sorry - (mine_sorry | set(missing)))
+    print(f"type-contains-sorry (extractor): {len(truth_sorry)}  "
+          f"answer-style skipped (parser): {len(mine_sorry)}")
+    print(f"UNCOVERED type-sorry statements (would become broken problems): "
+          f"{len(uncovered)} {uncovered[:10]}")
+
+    instance_only_missing = all("inst" in n.split(".")[-1] for n in missing)
+    ok = (not extra and not miscat and not uncovered
+          and (not missing or instance_only_missing))
+    print("CHECK:", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=PROBLEMS_ROOT,
+                        help="Problems root to generate into")
+    parser.add_argument("--ref", default=None,
+                        help="formal-conjectures ref (default: submodule tag)")
+    parser.add_argument("--categories", default=",".join(DEFAULT_CATEGORIES),
+                        help="Comma-separated categories to include")
+    parser.add_argument("--only", default=None,
+                        help="Generate only this fully-qualified theorem (any category)")
+    parser.add_argument("--wipe", action="store_true",
+                        help="Remove previously generated source dirs first")
+    parser.add_argument("--check-against", type=Path, default=None,
+                        help="Diff parser output against extract_names JSON and exit")
+    args = parser.parse_args()
+
+    if not (SUBMODULE / "FormalConjectures").is_dir():
+        print("ERROR: submodule not initialized. Run: git submodule update --init",
+              file=sys.stderr)
+        return 1
+
+    decls = parse_all(SUBMODULE)
+    categories = {c.strip() for c in args.categories.split(",")}
+
+    if args.check_against:
+        return check_against(decls, args.check_against, categories)
+
+    if args.ref:
+        ref = args.ref
+    else:
+        ref = subprocess.run(
+            ["git", "-C", str(SUBMODULE), "describe", "--tags", "--exact-match"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    lean_version = (SUBMODULE / "lean-toolchain").read_text().strip().split(":")[-1]
+
+    if args.wipe and not args.only:
+        for child in args.out.iterdir():
+            if child.is_dir() and child.name not in ("common", "docker", "_generator"):
+                shutil.rmtree(child)
+
+    generate(decls, args.out, ref, lean_version, categories, args.only)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/problems/formal_conjectures/_generator/shape_check.sh
+++ b/research/problems/formal_conjectures/_generator/shape_check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Validate every generated prove-or-disprove problem: its compiled statement
+# must be exactly `True ↔ Q` (see ShapeCheck.lean). Requires docker and the
+# prebuilt eval image. Run after (re)generation, especially on submodule bumps.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FC_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+FIRST_CFG=$(find "$FC_ROOT" -mindepth 3 -maxdepth 3 -name config.yaml -print -quit)
+if [ -z "$FIRST_CFG" ]; then
+  echo "no generated problems found (run generate.py first)" >&2
+  exit 1
+fi
+IMAGE=$(awk '/image:/ {print $2; exit}' "$FIRST_CFG")
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+python3 - "$FC_ROOT" > "$TMP/targets.txt" <<'EOF'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+for tj in sorted(root.glob("*/*/target.json")):
+    t = json.loads(tj.read_text(encoding="utf-8"))
+    if t.get("mode") == "prove_or_disprove":
+        print(" ".join(t["module"]) + " / " + " ".join(t["theorem"]))
+EOF
+echo "checking $(wc -l < "$TMP/targets.txt") prove-or-disprove targets against $IMAGE"
+cp "$SCRIPT_DIR/ShapeCheck.lean" "$TMP/"
+chmod -R a+rX "$TMP"
+docker run --rm -v "$TMP":/sc:ro "$IMAGE" \
+  bash -c 'cd /opt/formal-conjectures && lake env lean --root /sc --run /sc/ShapeCheck.lean /sc/targets.txt'

--- a/research/problems/formal_conjectures/common/CheckDriver.lean
+++ b/research/problems/formal_conjectures/common/CheckDriver.lean
@@ -1,0 +1,75 @@
+/-
+Trusted checker for formal_conjectures submissions.
+
+Run via `lake env lean --run CheckDriver.lean <module components> / <theorem
+components>` from the formal-conjectures package root, with the compiled
+submission (module `FCSolution`) on LEAN_PATH.
+
+This file only ever loads compiled .oleans via `importModules` — it never
+elaborates submission *syntax*, so submission-defined macros/elaborators can
+never influence the check. It verifies:
+  1. the submission declares a constant `solution`,
+  2. `solution` depends only on the standard axioms, and
+  3. `solution`'s type is definitionally equal to the target conjecture's
+     statement (the statement constant exists in the target module even when
+     its proof is `sorry`).
+
+Prints FC_CHECK_OK and exits 0 iff the submission is accepted.
+-/
+import Lean
+
+open Lean
+
+def allowedAxioms : List Name := [`propext, `Classical.choice, `Quot.sound]
+
+def mkNameFromComponents (cs : List String) : Name :=
+  cs.foldl .str .anonymous
+
+def fail (msg : String) : IO UInt32 := do
+  IO.eprintln s!"[driver] {msg}"
+  return 1
+
+def check (targetName : Name) : CoreM (Except String Unit) := do
+  let env ← getEnv
+  let some target := env.find? targetName
+    | return .error s!"target theorem {targetName} not found"
+  let some sol := env.find? `solution
+    | return .error "submission must declare a top-level `theorem solution : <statement>`"
+  if target.type.hasSorry then
+    return .error s!"target statement {targetName} contains sorry; problem is not checkable"
+
+  -- Axiom audit: catches sorryAx, native_decide (ofReduceBool), custom axioms.
+  let axioms ← collectAxioms `solution
+  for ax in axioms do
+    unless allowedAxioms.contains ax do
+      return .error s!"solution depends on forbidden axiom: {ax}"
+
+  -- Statement check: `solution`'s type must be defeq to the conjecture's.
+  unless target.levelParams.length == sol.levelParams.length do
+    return .error "universe parameter count differs from the conjecture statement"
+  let solType := sol.type.instantiateLevelParams sol.levelParams
+    (target.levelParams.map Level.param)
+  let ok ← Meta.MetaM.run' (Meta.isDefEq target.type solType)
+  unless ok do
+    return .error
+      s!"the type of `solution` does not match the statement of {targetName}"
+  return .ok ()
+
+def main (args : List String) : IO UInt32 := do
+  let (modComponents, rest) := args.span (· != "/")
+  let thmComponents := rest.drop 1
+  if modComponents.isEmpty || thmComponents.isEmpty then
+    return ← fail "usage: CheckDriver <module components> / <theorem components>"
+  let targetMod := mkNameFromComponents modComponents
+  let targetName := mkNameFromComponents thmComponents
+
+  initSearchPath (← findSysroot)
+  let env ← importModules #[{ module := targetMod }, { module := `FCSolution }] {}
+
+  let coreCtx : Core.Context := { fileName := "", fileMap := default }
+  let (result, _) ← (check targetName).toIO coreCtx { env := env }
+  match result with
+  | .error msg => return ← fail msg
+  | .ok () =>
+    IO.println "FC_CHECK_OK"
+    return 0

--- a/research/problems/formal_conjectures/common/CheckDriver.lean
+++ b/research/problems/formal_conjectures/common/CheckDriver.lean
@@ -2,17 +2,26 @@
 Trusted checker for formal_conjectures submissions.
 
 Run via `lake env lean --run CheckDriver.lean <module components> / <theorem
-components>` from the formal-conjectures package root, with the compiled
-submission (module `FCSolution`) on LEAN_PATH.
+components> [/ <mode>]` from the formal-conjectures package root, with the
+compiled submission (module `FCSolution`) on LEAN_PATH.
 
 This file only ever loads compiled .oleans via `importModules` — it never
 elaborates submission *syntax*, so submission-defined macros/elaborators can
 never influence the check. It verifies:
   1. the submission declares a constant `solution`,
   2. `solution` depends only on the standard axioms, and
-  3. `solution`'s type is definitionally equal to the target conjecture's
-     statement (the statement constant exists in the target module even when
-     its proof is `sorry`).
+  3. `solution`'s type matches the target, depending on <mode>:
+     - "prove" (default): definitionally equal to the target conjecture's
+       statement (the statement constant exists in the target module even
+       when its proof is `sorry`);
+     - "prove_or_disprove": the target is a fill-in-the-answer statement
+       whose `answer(sorry)` elaborated to a `True` placeholder, so its
+       compiled type must be literally `True ↔ Q`; the submission is accepted
+       iff `solution`'s type is definitionally equal to `Q` or to `¬Q`.
+
+Fail-closed: any shape the checker cannot positively verify (unexpected mode,
+target not of the form `True ↔ Q`, type matching neither side) is an error,
+which the evaluator scores 0.0.
 
 Prints FC_CHECK_OK and exits 0 iff the submission is accepted.
 -/
@@ -29,7 +38,7 @@ def fail (msg : String) : IO UInt32 := do
   IO.eprintln s!"[driver] {msg}"
   return 1
 
-def check (targetName : Name) : CoreM (Except String Unit) := do
+def check (targetName : Name) (mode : String) : CoreM (Except String Unit) := do
   let env ← getEnv
   let some target := env.find? targetName
     | return .error s!"target theorem {targetName} not found"
@@ -44,22 +53,42 @@ def check (targetName : Name) : CoreM (Except String Unit) := do
     unless allowedAxioms.contains ax do
       return .error s!"solution depends on forbidden axiom: {ax}"
 
-  -- Statement check: `solution`'s type must be defeq to the conjecture's.
   unless target.levelParams.length == sol.levelParams.length do
     return .error "universe parameter count differs from the conjecture statement"
   let solType := sol.type.instantiateLevelParams sol.levelParams
     (target.levelParams.map Level.param)
-  let ok ← Meta.MetaM.run' (Meta.isDefEq target.type solType)
-  unless ok do
+
+  match mode with
+  | "prove" =>
+    -- `solution`'s type must be defeq to the conjecture's statement.
+    let ok ← Meta.MetaM.run' (Meta.isDefEq target.type solType)
+    unless ok do
+      return .error
+        s!"the type of `solution` does not match the statement of {targetName}"
+    return .ok ()
+  | "prove_or_disprove" =>
+    -- Target must have the exact placeholder shape `True ↔ Q` (no reduction:
+    -- anything else fails closed). Accept a proof of `Q` or of `¬Q`.
+    unless target.type.isAppOfArity `Iff 2 do
+      return .error s!"target {targetName} is not a top-level iff; not checkable"
+    let lhs := target.type.appFn!.appArg!
+    let q := target.type.appArg!
+    unless lhs.isConstOf `True do
+      return .error s!"target {targetName} placeholder is not `True`; not checkable"
+    if ← Meta.MetaM.run' (Meta.isDefEq q solType) then
+      return .ok ()
+    if ← Meta.MetaM.run' (Meta.isDefEq (mkApp (mkConst `Not) q) solType) then
+      return .ok ()
     return .error
-      s!"the type of `solution` does not match the statement of {targetName}"
-  return .ok ()
+      s!"the type of `solution` proves neither the question of {targetName} nor its negation"
+  | _ => return .error s!"unknown check mode: {mode}"
 
 def main (args : List String) : IO UInt32 := do
   let (modComponents, rest) := args.span (· != "/")
-  let thmComponents := rest.drop 1
+  let (thmComponents, rest2) := (rest.drop 1).span (· != "/")
+  let mode := (rest2.drop 1).headD "prove"
   if modComponents.isEmpty || thmComponents.isEmpty then
-    return ← fail "usage: CheckDriver <module components> / <theorem components>"
+    return ← fail "usage: CheckDriver <module components> / <theorem components> [/ <mode>]"
   let targetMod := mkNameFromComponents modComponents
   let targetName := mkNameFromComponents thmComponents
 
@@ -67,7 +96,7 @@ def main (args : List String) : IO UInt32 := do
   let env ← importModules #[{ module := targetMod }, { module := `FCSolution }] {}
 
   let coreCtx : Core.Context := { fileName := "", fileMap := default }
-  let (result, _) ← (check targetName).toIO coreCtx { env := env }
+  let (result, _) ← (check targetName mode).toIO coreCtx { env := env }
   match result with
   | .error msg => return ← fail msg
   | .ok () =>

--- a/research/problems/formal_conjectures/common/fc_evaluator.py
+++ b/research/problems/formal_conjectures/common/fc_evaluator.py
@@ -12,9 +12,12 @@ The evaluator:
   3. Runs the trusted CheckDriver.lean, which loads only compiled .oleans
      (never elaborating submission syntax) and verifies that:
        - `solution`'s type is definitionally equal to the conjecture's
-         statement, and
+         statement (mode "prove", the default) — or, for fill-in-the-answer
+         problems (target.json mode "prove_or_disprove", statement compiled
+         as `True ↔ Q`), to `Q` or `¬Q`, and
        - `solution` depends only on the standard axioms
          (propext, Classical.choice, Quot.sound).
+     The driver fails closed: anything it cannot positively verify scores 0.0.
 
 Score contract (parsed by the framework from the last stdout line):
   1.0  proof accepted
@@ -76,6 +79,10 @@ def main() -> None:
     target = json.loads(Path(args.target).read_text(encoding="utf-8"))
     module = target["module"]      # list of module name components
     theorem = target["theorem"]    # list of declaration name components
+    # "prove": solution's type must match the statement. "prove_or_disprove":
+    # fill-in-the-answer statement `answer(sorry) ↔ Q`; solution must prove Q
+    # or ¬Q. The trusted driver fails closed on anything else.
+    mode = target.get("mode", "prove")
 
     # Infrastructure sanity: the image must match the ref the problem was
     # generated from, else statements could silently differ. Raise (no score
@@ -119,7 +126,8 @@ def main() -> None:
 
     print("[fc] running trusted checker...", file=sys.stderr)
     driver = Path(__file__).resolve().parent / "CheckDriver.lean"
-    driver_args = " ".join(shlex.quote(c) for c in [*module, "/", *theorem])
+    driver_args = " ".join(
+        shlex.quote(c) for c in [*module, "/", *theorem, "/", mode])
     proc = run(
         ["lake", "env", "bash", "-c",
          f'export LEAN_PATH="$LEAN_PATH:{tmp}"; '

--- a/research/problems/formal_conjectures/common/fc_evaluator.py
+++ b/research/problems/formal_conjectures/common/fc_evaluator.py
@@ -1,0 +1,138 @@
+"""
+Shared evaluator for formal_conjectures problems.
+
+A submission is a single `solution.lean` file that must declare a top-level
+
+    theorem solution : <exact statement of the target conjecture> := <proof>
+
+The evaluator:
+  1. Lints the source for constructs that could subvert checking.
+  2. Compiles it against the prebuilt formal-conjectures + Mathlib package
+     baked into the Docker image at /opt/formal-conjectures.
+  3. Runs the trusted CheckDriver.lean, which loads only compiled .oleans
+     (never elaborating submission syntax) and verifies that:
+       - `solution`'s type is definitionally equal to the conjecture's
+         statement, and
+       - `solution` depends only on the standard axioms
+         (propext, Classical.choice, Quot.sound).
+
+Score contract (parsed by the framework from the last stdout line):
+  1.0  proof accepted
+  0.0  rejected (compile error / sorry / wrong statement / forbidden axiom)
+An exception with no score line signals an infrastructure error.
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+FC_ROOT = Path(os.environ.get("FC_ROOT", "/opt/formal-conjectures"))
+
+# Rejected outright. The trusted driver makes most of these unexploitable
+# anyway (it never elaborates submission syntax); this is defense in depth,
+# and none are needed for an honest proof.
+FORBIDDEN_PATTERNS = [
+    (r"\baxiom\b", "axiom declarations are not allowed"),
+    (r"\bsorryAx\b", "direct use of sorryAx is not allowed"),
+    (r"\bmacro\b|\bmacro_rules\b", "macro definitions are not allowed"),
+    (r"\belab\b|\belab_rules\b", "elaborator definitions are not allowed"),
+    (r"\bsyntax\b", "syntax definitions are not allowed"),
+    (r"\bnotation\b", "notation definitions are not allowed"),
+    (r"\binitialize\b", "initializers are not allowed"),
+    (r"\brun_cmd\b|\brun_elab\b", "compile-time command execution is not allowed"),
+    (r"\bimplemented_by\b|\bextern\b", "native overrides are not allowed"),
+    (r"\bnative_decide\b|\bofReduceBool\b|\bofReduceNat\b",
+     "native_decide and native reduction axioms are not allowed"),
+    (r"\bunsafe\b", "unsafe definitions are not allowed"),
+    (r"set_option\s+debug\.", "debug options are not allowed"),
+]
+
+
+def reject(reason: str, detail: str = "") -> None:
+    """Print diagnostics to stderr and the 0.0 score to stdout, then exit."""
+    print(f"[fc] rejected: {reason}", file=sys.stderr)
+    if detail:
+        print(detail[-4000:], file=sys.stderr)
+    print("0.0")
+    sys.exit(0)
+
+
+def run(cmd: list, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--solution-path", required=True)
+    parser.add_argument("--target", required=True, help="Path to target.json")
+    args = parser.parse_args()
+
+    target = json.loads(Path(args.target).read_text(encoding="utf-8"))
+    module = target["module"]      # list of module name components
+    theorem = target["theorem"]    # list of declaration name components
+
+    # Infrastructure sanity: the image must match the ref the problem was
+    # generated from, else statements could silently differ. Raise (no score
+    # line) so the framework reports ERROR instead of a misleading 0.0.
+    expected_ref = target.get("ref")
+    actual_ref = os.environ.get("FC_REF", "")
+    if not actual_ref:
+        proc = run(["git", "describe", "--tags", "--always"], cwd=FC_ROOT)
+        actual_ref = proc.stdout.strip()
+    if expected_ref and actual_ref and expected_ref != actual_ref:
+        raise RuntimeError(
+            f"image formal-conjectures ref {actual_ref!r} does not match "
+            f"problem ref {expected_ref!r}; rebuild the eval image"
+        )
+
+    solution_path = Path(args.solution_path)
+    if not solution_path.exists():
+        raise FileNotFoundError(f"solution not found: {solution_path}")
+    src = solution_path.read_text(encoding="utf-8")
+
+    for pattern, reason in FORBIDDEN_PATTERNS:
+        if re.search(pattern, src):
+            reject(reason)
+
+    tmp = Path(tempfile.mkdtemp(prefix="fcsol_"))
+    (tmp / "FCSolution.lean").write_text(src, encoding="utf-8")
+
+    print("[fc] compiling solution...", file=sys.stderr)
+    proc = run(
+        ["lake", "env", "lean",
+         "--root", str(tmp),
+         "-o", str(tmp / "FCSolution.olean"),
+         str(tmp / "FCSolution.lean")],
+        cwd=FC_ROOT,
+    )
+    output = proc.stdout + "\n" + proc.stderr
+    if proc.returncode != 0:
+        reject("solution failed to compile", output)
+    if "declaration uses 'sorry'" in output:
+        reject("solution uses sorry", output)
+
+    print("[fc] running trusted checker...", file=sys.stderr)
+    driver = Path(__file__).resolve().parent / "CheckDriver.lean"
+    driver_args = " ".join(shlex.quote(c) for c in [*module, "/", *theorem])
+    proc = run(
+        ["lake", "env", "bash", "-c",
+         f'export LEAN_PATH="$LEAN_PATH:{tmp}"; '
+         f"exec lean --root {shlex.quote(str(driver.parent))} "
+         f"--run {shlex.quote(str(driver))} {driver_args}"],
+        cwd=FC_ROOT,
+    )
+    if proc.returncode != 0 or "FC_CHECK_OK" not in proc.stdout:
+        reject("proof check failed", proc.stdout + "\n" + proc.stderr)
+
+    print("[fc] proof accepted", file=sys.stderr)
+    print("1.0")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/problems/formal_conjectures/docker/Dockerfile
+++ b/research/problems/formal_conjectures/docker/Dockerfile
@@ -1,0 +1,37 @@
+# Evaluation image for formal_conjectures problems.
+#
+# Contains Lean 4 (pinned by the formal-conjectures lean-toolchain), a fully
+# built checkout of google-deepmind/formal-conjectures (including Mathlib via
+# `lake exe cache get`), and python3 for the evaluator orchestrator.
+#
+# FC_REF must match the tag the third_party/formal-conjectures submodule is
+# pinned to — build via build.sh, which derives it from the submodule.
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates bash python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+ENV PATH="/root/.elan/bin:${PATH}"
+
+ARG FC_REF=bench-v1-lean4.27.0
+RUN git clone --depth 1 --branch ${FC_REF} \
+        https://github.com/google-deepmind/formal-conjectures /opt/formal-conjectures
+
+WORKDIR /opt/formal-conjectures
+
+# Mathlib olean cache, then compile the conjecture statements themselves.
+# (lake 5.x has no jobs flag; parallelism follows available cores.)
+RUN lake exe cache get
+RUN lake build
+# The upstream extractor exe, used once to generate the problem manifest.
+RUN lake build extract_names
+
+# Smoke test: a trivial standalone theorem compiles against the built package.
+RUN echo 'theorem solution : True := trivial' > /tmp/smoke.lean \
+    && lake env lean /tmp/smoke.lean \
+    && rm /tmp/smoke.lean
+
+# Stamp the pinned ref so the evaluator can verify image/problem consistency.
+ENV FC_REF=${FC_REF}

--- a/research/problems/formal_conjectures/docker/build.sh
+++ b/research/problems/formal_conjectures/docker/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build (and optionally push) the formal_conjectures evaluation image.
+#
+# The image tag is derived from the third_party/formal-conjectures submodule
+# pin so the image and the generated problems can never drift apart silently.
+#
+# Usage: ./build.sh [--push]
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SUBMODULE="$REPO_ROOT/third_party/formal-conjectures"
+
+if [ ! -f "$SUBMODULE/lean-toolchain" ]; then
+    echo "ERROR: submodule not initialized. Run: git submodule update --init" >&2
+    exit 1
+fi
+
+FC_REF=$(git -C "$SUBMODULE" describe --tags --exact-match)
+IMAGE="${IMAGE:-shangyint/formal-conjectures-eval}"
+
+echo "Building $IMAGE:$FC_REF (formal-conjectures @ $FC_REF)"
+docker build --build-arg "FC_REF=$FC_REF" -t "$IMAGE:$FC_REF" "$SCRIPT_DIR"
+
+if [ "${1:-}" = "--push" ]; then
+    docker push "$IMAGE:$FC_REF"
+fi

--- a/research/scripts/check_solutions.py
+++ b/research/scripts/check_solutions.py
@@ -112,7 +112,9 @@ def info(text: str) -> str:
 
 
 # Directories to exclude when auto-discovering problems
-EXCLUDE_DIRS = {"common", "resources", "__pycache__", ".venv"}
+# formal_conjectures problems are auto-generated Lean proof tasks with no
+# expected LLM solutions; keep them out of the solutions matrix and problems.txt.
+EXCLUDE_DIRS = {"common", "resources", "__pycache__", ".venv", "formal_conjectures"}
 
 
 def discover_problems(problems_dir: Path) -> List[Tuple[str, Path]]:

--- a/scripts/detect_changed_problems.py
+++ b/scripts/detect_changed_problems.py
@@ -75,6 +75,13 @@ def detect_changed_problems(track: str, base_ref: str = "origin/main") -> list[s
                 is_problem = (problem_dir / "evaluator.py").exists()
 
             if is_problem:
+                # Problem families marked with a `.skip-validation` file (in the
+                # problem dir or any ancestor) are excluded from CI validation.
+                # Used by research/problems/formal_conjectures/: open conjectures
+                # cannot have a reference solution scoring > 0 by design.
+                ancestors = [Path(prefix + "/".join(parts[:j])) for j in range(i + 1)]
+                if any((d / ".skip-validation").exists() for d in ancestors):
+                    break
                 problems.add(candidate)
                 break
 

--- a/scripts/update_problem_count.py
+++ b/scripts/update_problem_count.py
@@ -17,10 +17,11 @@ def count_research_problems(research_dir: Path) -> int:
     if poc_dir.exists():
         count += 4
     
-    # Count all evaluator.py files, excluding those in poc_generation
+    # Count all evaluator.py files, excluding those in poc_generation and
+    # formal_conjectures (auto-generated Lean problems, counted separately)
     for evaluator_file in research_dir.rglob('evaluator.py'):
         # Skip if it's under poc_generation directory
-        if 'poc_generation' not in str(evaluator_file):
+        if 'poc_generation' not in str(evaluator_file) and 'formal_conjectures' not in str(evaluator_file):
             count += 1
     
     return count

--- a/scripts/validate_problems.py
+++ b/scripts/validate_problems.py
@@ -90,6 +90,16 @@ def validate_problem(
     print(f"Validating: {problem_id}")
     print("=" * 60)
 
+    # Problem families marked with `.skip-validation` (e.g. formal_conjectures)
+    # have no reference solution by design; treat as passing without running.
+    problem_dir = Path(f"{track}/problems/{problem_id}")
+    for d in [problem_dir, *problem_dir.parents]:
+        if (d / ".skip-validation").exists():
+            print("  SKIP: .skip-validation marker (no reference solution by design)")
+            return True
+        if d == Path(f"{track}/problems"):
+            break
+
     # Find reference solution
     ref_path = find_reference_solution(track, problem_id)
     if ref_path is None:

--- a/src/frontier_cs/config.py
+++ b/src/frontier_cs/config.py
@@ -218,6 +218,11 @@ LANGUAGE_CONFIGS: Dict[str, LanguageConfig] = {
         extension="rs",
         code_block_tag="rust",
     ),
+    "lean": LanguageConfig(
+        name="lean",
+        extension="lean",
+        code_block_tag="lean",
+    ),
 }
 
 DEFAULT_LANGUAGE = "python"

--- a/src/frontier_cs/lazy_problems.py
+++ b/src/frontier_cs/lazy_problems.py
@@ -10,6 +10,7 @@ directories are missing or were generated from a different submodule commit.
 Afterwards everything is served directly from the files.
 """
 
+import hashlib
 import subprocess
 import sys
 from pathlib import Path
@@ -35,10 +36,11 @@ def ensure_formal_conjectures(problems_dir: Path, problem_id: Optional[str] = No
 
     No-op when: this problems tree has no formal_conjectures generator, the
     requested problem id is not a formal_conjectures one, or generation is
-    already up to date with the submodule commit (stamped in
-    _generator/.generated-ref by the generator). Failures are reported on
-    stderr but never raised — the caller then fails naturally with
-    problem-not-found.
+    already up to date with the submodule commit and generator version
+    (stamped as "<submodule-head>+<generator-hash>" in
+    _generator/.generated-ref by the generator; must stay in sync with
+    generation_stamp() there). Failures are reported on stderr but never
+    raised — the caller then fails naturally with problem-not-found.
     """
     if problems_dir in _verified:
         return
@@ -62,9 +64,10 @@ def ensure_formal_conjectures(problems_dir: Path, problem_id: Optional[str] = No
             return
 
     head = _submodule_head(repo_root)
+    ghash = hashlib.sha256(generator.read_bytes()).hexdigest()[:16]
     stamp_file = fc_root / "_generator" / ".generated-ref"
     stamp = stamp_file.read_text(encoding="utf-8").strip() if stamp_file.is_file() else None
-    if head is not None and stamp == head:
+    if head is not None and stamp == f"{head}+{ghash}":
         _verified.add(problems_dir)
         return  # up to date; a missing problem id is genuinely unknown
 

--- a/src/frontier_cs/lazy_problems.py
+++ b/src/frontier_cs/lazy_problems.py
@@ -1,0 +1,82 @@
+"""
+Lazy materialization of generated problem directories.
+
+formal_conjectures problem dirs are generated from the
+third_party/formal-conjectures submodule and are not committed (see
+research/problems/formal_conjectures/.gitignore). This module regenerates them
+transparently on first access: resolving a formal_conjectures problem id
+(eval, show) or listing research problems triggers generation when the
+directories are missing or were generated from a different submodule commit.
+Afterwards everything is served directly from the files.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+FC = "formal_conjectures"
+
+# problems_dirs verified current in this process; skip repeat git/stamp checks
+_verified = set()
+
+
+def _submodule_head(repo_root: Path) -> Optional[str]:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root / "third_party" / "formal-conjectures"),
+         "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def ensure_formal_conjectures(problems_dir: Path, problem_id: Optional[str] = None) -> None:
+    """Generate formal_conjectures problem dirs if missing or stale.
+
+    No-op when: this problems tree has no formal_conjectures generator, the
+    requested problem id is not a formal_conjectures one, or generation is
+    already up to date with the submodule commit (stamped in
+    _generator/.generated-ref by the generator). Failures are reported on
+    stderr but never raised — the caller then fails naturally with
+    problem-not-found.
+    """
+    if problems_dir in _verified:
+        return
+    if problem_id is not None and not str(problem_id).startswith(FC + "/"):
+        return
+    fc_root = problems_dir / FC
+    generator = fc_root / "_generator" / "generate.py"
+    if not generator.is_file():
+        return
+
+    repo_root = problems_dir.parents[1]
+    submodule = repo_root / "third_party" / "formal-conjectures"
+    if not (submodule / "FormalConjectures").is_dir():
+        subprocess.run(
+            ["git", "submodule", "update", "--init", "third_party/formal-conjectures"],
+            cwd=repo_root, capture_output=True,
+        )
+        if not (submodule / "FormalConjectures").is_dir():
+            print(f"[{FC}] submodule not initialized and auto-init failed; "
+                  "run: git submodule update --init", file=sys.stderr)
+            return
+
+    head = _submodule_head(repo_root)
+    stamp_file = fc_root / "_generator" / ".generated-ref"
+    stamp = stamp_file.read_text(encoding="utf-8").strip() if stamp_file.is_file() else None
+    if head is not None and stamp == head:
+        _verified.add(problems_dir)
+        return  # up to date; a missing problem id is genuinely unknown
+
+    print(f"[{FC}] materializing problem directories from the submodule...",
+          file=sys.stderr)
+    proc = subprocess.run(
+        [sys.executable, str(generator), "--wipe"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        print(f"[{FC}] generation failed:\n{proc.stderr}", file=sys.stderr)
+        return
+    summary = proc.stdout.splitlines()[0] if proc.stdout else ""
+    print(f"[{FC}] {summary}", file=sys.stderr)
+    _verified.add(problems_dir)

--- a/src/frontier_cs/runner/base.py
+++ b/src/frontier_cs/runner/base.py
@@ -128,7 +128,13 @@ class ResearchRunner(Runner):
 
         With nested solution structure, problem_id is already the nested path
         (e.g., "cant_be_late/high_availability_loose_deadline_large_overhead").
+
+        formal_conjectures problems are generated from a submodule rather than
+        committed; materialize them on first access.
         """
+        from ..lazy_problems import ensure_formal_conjectures
+
+        ensure_formal_conjectures(self.problems_dir, problem_id)
         return self.problems_dir / problem_id
 
     def _get_problem_path_or_error(

--- a/src/frontier_cs/single_evaluator.py
+++ b/src/frontier_cs/single_evaluator.py
@@ -307,6 +307,11 @@ class SingleEvaluator:
         if not research_problems_dir.exists():
             return []
 
+        # formal_conjectures problems are generated from a submodule rather
+        # than committed; materialize them so they appear in the listing.
+        from .lazy_problems import ensure_formal_conjectures
+        ensure_formal_conjectures(research_problems_dir)
+
         problems = []
         
         # Special case: poc_generation has 4 subcategories


### PR DESCRIPTION
Note: ENTIRELY AI GENERATED!

## Summary
Adds 1,716 Lean 4 theorem-proving problems generated from the
[google-deepmind/formal-conjectures](https://github.com/google-deepmind/formal-conjectures)
library (vendored as a submodule at `bench-v1-lean4.27.0`):

- **1,170 "prove" problems** — research open/solved conjectures with fully
  concrete statements; submit a `theorem solution` definitionally equal to the
  statement.
- **546 "prove-or-disprove" problems** — fill-in-the-answer statements
  (`answer(sorry) ↔ Q`); submit a proof of `Q` or of `¬Q`.

Problem directories are generated, not committed: they materialize lazily on
first `frontier list|eval|show` access (`src/frontier_cs/lazy_problems.py`),
stamped by submodule commit + generator hash. Scoring is binary and fail-closed:
a trusted Lean driver (`common/CheckDriver.lean`) loads only compiled oleans
(never elaborates submission syntax), checks definitional equality of the
solution's type (against the statement, or against `Q`/`¬Q` extracted from the
compiled `True ↔ Q` placeholder), audits axioms, and anything it cannot
positively verify scores 0.0. Each problem dir ships a `check.sh` for
one-command local scoring; `_generator/shape_check.sh` validates all
prove-or-disprove targets on regeneration.

**Known gap:** the eval image
`shangyint/formal-conjectures-eval:bench-v1-lean4.27.0` (13.5 GB) exists only on
my machine and is not yet on Docker Hub — evaluation is not reproducible by
others until it is pushed.

## Type of Change
- [x] New research problem
- [ ] New algorithmic problem
- [ ] New Frontier-CS 2.0 problem
- [ ] Bug fix
- [x] Documentation update
- [ ] Other:

## Testing
- Evaluator E2E (prove mode): known proof → 1.0; `sorry` / wrong statement /
  forbidden-axiom cheat → 0.0.
- Trusted driver test matrix in-image (9 cases, prove-or-disprove mode):
  accepts proofs of `Q` and of `¬Q`; rejects wrong types, non-iff targets,
  unknown modes; legacy invocation unchanged.
- Full-stack prove-or-disprove reject verified on a real problem
  (`Erdos326.erdos_326` → 0.0 "proves neither"). A full-evaluator **1.0 in this
  mode has NOT been exercised** — every such problem is a genuine research
  question; the accept path is covered at the driver level only.
- Shape sweep: all 546 prove-or-disprove targets confirmed to compile to
  exactly `True ↔ Q` (the sweep caught and excluded 5 section-variable
  statements that would have been permanently zero).
- Agent baseline smoke test: one headless `claude -p` run on a random problem
  (infrastructure exercised end-to-end; no solve, as expected).

## Checklist
- [x] Code follows the project structure and conventions
- [ ] Self-review completed (diff reviewed with Claude; human pass pending)
- [x] Documentation updated (CONTRIBUTING.md: generation, modes, regeneration
  and shape-check procedure)

## CI Validation (for new problems)
No — intentionally not applicable. These problems carry a `.skip-validation`
marker and include no `reference.py`: they are open (or research-grade solved)
conjectures, so no reference solution scoring > 0 can exist. They are likewise
excluded from `research/scripts/problems.txt` and the README problem count.
