### PR TITLE
Fix #176: score only from checker-produced output

### DIFF
--- a/algorithmic/judge/src/judge_engine.js
+++ b/algorithmic/judge/src/judge_engine.js
@@ -4,6 +4,39 @@ import { toNs, toBytes, fileExists } from './utils.js';
 import { GoJudgeClient } from './gojudge.js';
 import { ProblemManager } from './problem_manager.js';
 
+// testlib exit codes meaning "the checker/interactor deliberately reported a
+// (possibly partial) score": quitf(_ok, ...) and quitp(points, ...).
+const TESTLIB_OK_EXIT_CODE = 0;
+const TESTLIB_POINTS_EXIT_CODE = 7;
+
+// True when a checker/interactor run finished on its own with a scoring verdict,
+// i.e. its output is a trustworthy source for a `Ratio:` value. A killed run
+// (TLE/MLE/signal) or a non-scoring verdict (_wa, _pe, _fail) reports no score.
+function isScoringVerdict(res) {
+    if (res.status !== 'Accepted' && res.status !== 'Nonzero Exit Status') return false;
+    return res.exitStatus === TESTLIB_OK_EXIT_CODE || res.exitStatus === TESTLIB_POINTS_EXIT_CODE;
+}
+
+function parseRatio(match) {
+    if (!match) return null;
+    const value = parseFloat(match[1]);
+    return Number.isFinite(value) ? value : null;
+}
+
+// Compute the score ratio for one case. Only `judgeMsg` - output produced by the
+// checker or interactor - may be parsed. A case result's `msg` can be the
+// contestant's own stderr (when the run fails the checker never runs at all), so
+// scoring from it would let a submission print its own `Ratio:` and pick its score.
+function applyScoreRatio(r) {
+    const judgeMsg = r.judgeMsg || '';
+    const bounded = parseRatio(judgeMsg.match(/Ratio: ([\d.]+)/));
+    const unbounded = parseRatio(judgeMsg.match(/RatioUnbounded: ([\d.]+)/));
+
+    r.scoreRatio = bounded !== null ? bounded : (r.ok ? 1.0 : 0);
+    r.scoreRatioUnbounded = unbounded !== null ? unbounded : r.scoreRatio;
+    return r;
+}
+
 export class JudgeEngine {
     constructor(config) {
         this.problemManager = new ProblemManager({
@@ -192,12 +225,15 @@ export class JudgeEngine {
         }
 
         if (runRes.status !== 'Accepted') {
-            return { 
-                ok: false, 
-                status: runRes.status, 
-                time: runRes.runTime, 
-                memory: runRes.memory, 
-                msg: (runRes.files?.stderr || '' ) + extra
+            // The checker never ran, so there is no judge verdict for this case.
+            // `msg` is the contestant's own stderr: diagnostics only, never scored.
+            return {
+                ok: false,
+                status: runRes.status,
+                time: runRes.runTime,
+                memory: runRes.memory,
+                msg: (runRes.files?.stderr || '' ) + extra,
+                judgeMsg: ''
             };
         }
 
@@ -222,12 +258,14 @@ export class JudgeEngine {
         });
 
         const ok = chkRes.status === 'Accepted' && chkRes.exitStatus === 0;
+        const chkMsg = chkRes.files?.stdout || chkRes.files?.stderr || '';
         return {
             ok,
             status: ok ? 'Accepted' : 'Wrong Answer',
             time: runRes.runTime,
             memory: runRes.memory,
-            msg: chkRes.files?.stdout || chkRes.files?.stderr || '',
+            msg: chkMsg,
+            judgeMsg: isScoringVerdict(chkRes) ? chkMsg : '',
             output: out
         };
     }
@@ -282,24 +320,31 @@ export class JudgeEngine {
         const submissionRes = interactRes[0];
         const interactorRes = interactRes[1];
 
+        // Only the interactor's own output may be scored; the contestant's stderr
+        // is diagnostics. `judgeMsg` therefore never carries submission output.
+        const interactorMsg = (interactorRes.files?.stdout || '') + (interactorRes.files?.stderr || '');
+        const interactorJudgeMsg = isScoringVerdict(interactorRes) ? interactorMsg : '';
+
         if (submissionRes.status === 'Accepted' && interactorRes.status === 'Accepted' && interactorRes.exitStatus === 0 && submissionRes.exitStatus === 0 ) {
             return {
                 ok: true,
                 status: 'Accepted',
                 time: submissionRes.runTime,
                 memory: Math.max(submissionRes.memory, interactorRes.memory),
-                msg: (interactorRes.files?.stdout || '') + (interactorRes.files?.stderr || '')
+                msg: interactorMsg,
+                judgeMsg: interactorJudgeMsg
             };
         }
         if (submissionRes.status !== 'Accepted') {
             let extra = (submissionRes.status === 'Signalled') ? ` (signal=${submissionRes.error || 'unknown'})` : '';
-            return { ok: false, status: submissionRes.status, time: submissionRes.runTime, memory: submissionRes.memory, msg: (submissionRes.files?.stderr || '') + extra };
+            // The run itself failed (TLE/MLE/RE): no credit, whatever either side printed.
+            return { ok: false, status: submissionRes.status, time: submissionRes.runTime, memory: submissionRes.memory, msg: (submissionRes.files?.stderr || '') + extra, judgeMsg: '' };
         }
         if (interactorRes.status !== 'Accepted') {
-            return { ok: false, status: interactorRes.status, time: submissionRes.runTime, memory: submissionRes.memory, msg: (interactorRes.files?.stderr || '') };
+            return { ok: false, status: interactorRes.status, time: submissionRes.runTime, memory: submissionRes.memory, msg: (interactorRes.files?.stderr || ''), judgeMsg: interactorJudgeMsg };
         }
         // Default to WA if interactor exits non-zero
-        return { ok: false, status: 'Wrong Answer', time: submissionRes.runTime, memory: submissionRes.memory, msg: (interactorRes.files?.stderr || '') };
+        return { ok: false, status: 'Wrong Answer', time: submissionRes.runTime, memory: submissionRes.memory, msg: (interactorRes.files?.stderr || ''), judgeMsg: interactorJudgeMsg };
     }
 
     // Start worker threads
@@ -324,29 +369,15 @@ export class JudgeEngine {
             // let totalScoreUnbounded = 0;
             // const caseResults = [];
             // for (const c of problem.cases) {
-            //     const r = await this.judgeCase({ runSpec, caseItem: c, problem, checkerId });
-                
-            //     const matchBounded = r.msg.match(/Ratio: ([\d.]+)/);
-            //     const matchUnbounded = r.msg.match(/RatioUnbounded: ([\d.]+)/);
-                
-            //     r.scoreRatio = matchBounded ? parseFloat(matchBounded[1]) : (r.ok ? 1.0 : 0);
-            //     r.scoreRatioUnbounded = matchUnbounded ? parseFloat(matchUnbounded[1]) : r.scoreRatio;
-                
+            //     const r = applyScoreRatio(await this.judgeCase({ runSpec, caseItem: c, problem, checkerId }));
+
             //     totalScore += r.scoreRatio;
             //     totalScoreUnbounded += r.scoreRatioUnbounded;
             //     caseResults.push(r);
             // }
             
             const casePromises = problem.cases.map(async (c) => {
-                const r = await this.judgeCase({ runSpec, caseItem: c, problem, checkerId });
-
-                const matchBounded = r.msg.match(/Ratio: ([\d.]+)/);
-                const matchUnbounded = r.msg.match(/RatioUnbounded: ([\d.]+)/);
-
-                r.scoreRatio = matchBounded ? parseFloat(matchBounded[1]) : (r.ok ? 1.0 : 0);
-                r.scoreRatioUnbounded = matchUnbounded ? parseFloat(matchUnbounded[1]) : r.scoreRatio;
-
-                return r;
+                return applyScoreRatio(await this.judgeCase({ runSpec, caseItem: c, problem, checkerId }));
             });
 
             const caseResults = await Promise.all(casePromises);
@@ -368,7 +399,8 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses based on scoreRatio
-            const finalCases = caseResults.map(caseResult => ({
+            // (judgeMsg is dropped: it is already reported through msg)
+            const finalCases = caseResults.map(({ judgeMsg, ...caseResult }) => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));
@@ -417,30 +449,16 @@ export class JudgeEngine {
             // let totalScoreUnbounded = 0;
             // const caseResults = [];
             // for (const c of problem.cases) {
-            //     const r = await this.judgeInteractiveCase({ runSpec, caseItem: c, problem, interactorId });
-                
-            //     // Parse score ratio from interactor message
-            //     const matchBounded = r.msg.match(/Ratio: ([\d.]+)/);
-            //     const matchUnbounded = r.msg.match(/RatioUnbounded: ([\d.]+)/);
-                
-            //     r.scoreRatio = matchBounded ? parseFloat(matchBounded[1]) : (r.ok ? 1.0 : 0);
-            //     r.scoreRatioUnbounded = matchUnbounded ? parseFloat(matchUnbounded[1]) : r.scoreRatio;
-                
+            //     // Score ratio comes from the interactor's message only
+            //     const r = applyScoreRatio(await this.judgeInteractiveCase({ runSpec, caseItem: c, problem, interactorId }));
+
             //     totalScore += r.scoreRatio;
             //     totalScoreUnbounded += r.scoreRatioUnbounded;
             //     caseResults.push(r);
             // }
 
             const casePromises = problem.cases.map(async (c) => {
-                const r = await this.judgeInteractiveCase({ runSpec, caseItem: c, problem, interactorId });
-
-                const matchBounded = r.msg.match(/Ratio: ([\d.]+)/);
-                const matchUnbounded = r.msg.match(/RatioUnbounded: ([\d.]+)/);
-
-                r.scoreRatio = matchBounded ? parseFloat(matchBounded[1]) : (r.ok ? 1.0 : 0);
-                r.scoreRatioUnbounded = matchUnbounded ? parseFloat(matchUnbounded[1]) : r.scoreRatio;
-
-                return r;
+                return applyScoreRatio(await this.judgeInteractiveCase({ runSpec, caseItem: c, problem, interactorId }));
             });
 
             const caseResults = await Promise.all(casePromises);
@@ -458,7 +476,8 @@ export class JudgeEngine {
             const finalScoreUnbounded = problem.cases.length > 0 ? (totalScoreUnbounded / problem.cases.length) * 100 : 0;
 
             // Remap individual case statuses for clarity
-            const finalCases = caseResults.map(caseResult => ({
+            // (judgeMsg is dropped: it is already reported through msg)
+            const finalCases = caseResults.map(({ judgeMsg, ...caseResult }) => ({
                 ...caseResult,
                 status: caseResult.scoreRatio === 1.0 ? 'Correct' : 'Wrong Answer'
             }));


### PR DESCRIPTION
Fixes #176.

## The bug

`judgeCase()` returns the contestant's own stderr as `msg` whenever the run fails — on TLE/MLE/RE the checker never runs, so there is no checker output to report:

```js
if (runRes.status !== 'Accepted') {
    return { ok: false, ..., msg: (runRes.files?.stderr || '') + extra };
}
```

Both scoring loops then parsed that field unconditionally:

```js
const matchBounded = r.msg.match(/Ratio: ([\d.]+)/);
r.scoreRatio = matchBounded ? parseFloat(matchBounded[1]) : (r.ok ? 1.0 : 0);
```

So a submission that writes `Ratio: 1.0000` to stderr and then deliberately times out gets `scoreRatio = 1.0` on that case. It propagates all the way through `totalScore`, the final `(totalScore / cases) * 100`, `passed`, and the per-case status remap — a program whose output the checker never accepted reports 100 with every case shown as `Correct`.

## The fix

**Score provenance is split from diagnostics.** Case results now carry a `judgeMsg` populated only from checker/interactor output, and scoring reads that field alone. `msg` is unchanged and still reported, so failure diagnostics remain visible to users; they just can no longer reach the scorer.

**A ratio is honoured only from a real scoring verdict.** `isScoringVerdict()` requires the judge program to have exited on its own (not killed by a limit) with testlib's `_ok` (0) or `_points` (7). This also closes a second-order vector not in the original report: testlib WA messages routinely echo contestant tokens back (`expected 7, found "…"`), so a `Ratio:` smuggled through the checker's own WA text is ignored too.

**Existing partial credit is unaffected.** All 198 problems that emit `Ratio:` do so via `quitp(...)` or `quitf(_ok, ...)`, and the bundled `testlib.h` maps those to exit 0/7 with no `TESTSYS`/`CONTESTER` define in the checker compile flags.

**Interactive path**: a failed *submission* now yields no ratio, while the *interactor's* verdict is still trusted on its own failure paths — that is where interactive partial credit legitimately comes from (`quitp` → exit 7 → `Nonzero Exit Status`).

The duplicated parse in the batch and interactive loops is extracted into `applyScoreRatio()`, which also guards against `parseFloat` returning `NaN`. The commented-out sequential loops were updated to match so the vulnerable snippet isn't left waiting to be re-enabled. `judgeMsg` is stripped when building `finalCases`, so `result.json` keeps its existing shape.

## Verification

Both `judgeDefault` and `judgeInteractive` were driven end-to-end against a stubbed sandbox.

Against `main`, the exploit — print `Ratio: 1.0000` to stderr, then TLE — scores **100, `passed=true`, every case `Correct`**. With this change it scores **0**, and the honest paths are unchanged:

| scenario | before | after |
| --- | --- | --- |
| TLE + faked `Ratio: 1.0` in stderr | 100 ✗ | **0** |
| interactive RE + faked `Ratio: 1.0` | 100 ✗ | **0** |
| accepted (`quitf(_ok)`, exit 0) | 100 | 100 |
| partial credit (`quitp`, exit 7) | 50 | 50 |
| interactive partial credit (`quitp`, exit 7) | 75 | 75 |
| WA message quoting contestant `Ratio:` text | 1.0 ✗ | **0** |
| checker itself TLEs | — | 0 |

Contestant stderr is still surfaced in `msg` for debugging.

## Noted separately, not changed here

`algorithmic/problems/188/checker.cc:54` formats `Ratio: %.4f%%` — a percentage. A true ratio of 0.855 prints as `Ratio: 85.5000%`, which the scorer reads as 85.5, giving a final score of 8550 rather than 85.5. That is a per-problem bug; the scorer is deliberately left unclamped rather than silently masking it, since clamping to 1.0 would turn it into a false perfect score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
